### PR TITLE
Add nodeName to values.schema.json and bump version to 1.8.1

### DIFF
--- a/complex/Chart.yaml
+++ b/complex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: complex
 description: For deploying applications with consumers and cronjobs
 type: application
-version: 1.8.0
+version: 1.8.1
 kubeVersion: ">= 1.25.0-0 < 2.0.0-0"
 
 dependencies:

--- a/complex/values.schema.json
+++ b/complex/values.schema.json
@@ -1235,6 +1235,10 @@
             "Default",
             "None"
           ]
+        },
+        "nodeName": {
+          "description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.",
+          "type": "string"
         }
       },
       "additionalProperties": false
@@ -3183,6 +3187,10 @@
               "Default",
               "None"
             ]
+          },
+          "nodeName": {
+            "description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.",
+            "type": "string"
           },
           "service": {
             "type": "object",


### PR DESCRIPTION
Allow nodeName property in both pod definition and component definitions to fix validation error when scheduling pods to specific nodes.