### PR TITLE
feat(complex): add Recreate deployment strategy support

### DIFF
--- a/complex/Chart.yaml
+++ b/complex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: complex
 description: For deploying applications with consumers and cronjobs
 type: application
-version: 1.8.1
+version: 1.8.2
 kubeVersion: ">= 1.25.0-0 < 2.0.0-0"
 
 dependencies:

--- a/complex/templates/deployment.yaml
+++ b/complex/templates/deployment.yaml
@@ -20,11 +20,16 @@ metadata:
 spec:
   replicas: {{ $component.replicas }}
   progressDeadlineSeconds: {{ default 300 $component.progressDeadlineSeconds }}
+  {{- if eq (default "RollingUpdate" $component.strategyType) "Recreate" }}
+  strategy:
+    type: Recreate
+  {{- else }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: {{ coalesce (index $component "rollingUpdate" | default dict).maxUnavailable $.Values.global.rollingUpdate.maxUnavailable | quote}}
       maxSurge: {{ coalesce (index $component "rollingUpdate" | default dict).maxSurge $.Values.global.rollingUpdate.maxSurge | quote}}
+  {{- end }}
   selector:
     matchLabels:
       {{ include "cookielab.kubernetes.labels.selector" $kubeLabels | indent 6 | trim }}

--- a/complex/values.schema.json
+++ b/complex/values.schema.json
@@ -2693,6 +2693,15 @@
         "rollingUpdate": {
           "$ref": "#/definitions/rollingUpdate"
         },
+        "strategyType": {
+          "description": "Deployment strategy type. 'RollingUpdate' gradually replaces pods, 'Recreate' kills all existing pods before creating new ones.",
+          "type": "string",
+          "enum": [
+            "RollingUpdate",
+            "Recreate"
+          ],
+          "default": "RollingUpdate"
+        },
         "nodeSelector": {
           "$ref": "#/definitions/nodeSelector"
         },
@@ -3100,6 +3109,15 @@
           },
           "rollingUpdate": {
             "$ref": "#/definitions/rollingUpdate"
+          },
+          "strategyType": {
+            "description": "Deployment strategy type. 'RollingUpdate' gradually replaces pods, 'Recreate' kills all existing pods before creating new ones.",
+            "type": "string",
+            "enum": [
+              "RollingUpdate",
+              "Recreate"
+            ],
+            "default": "RollingUpdate"
           },
           "envs": {
             "type": "object",


### PR DESCRIPTION
Allow setting strategyType to "Recreate" on components. This is needed for hostNetwork pods where the old pod must release ports before the new one starts. Defaults to RollingUpdate for backwards compatibility. Bump version to 1.8.2.