### PR TITLE
test(complex): add helm-unittest suites and testing-values for recent…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,7 +151,7 @@ jobs:
           version: '3.13.0'
 
       - name: Download dependencies
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: helm-dependencies
           path: complex/charts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,7 +146,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: '3.13.0'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,7 +129,7 @@ jobs:
           helm template test ./complex --debug -f complex/testing-values/values-recreate.yaml
           helm template test ./complex --debug -f complex/testing-values/values-host-network.yaml
           helm template test ./complex --debug -f complex/testing-values/values-node-name.yaml
-          
+
           # Test infrastructure configurations
           helm template test ./complex --debug -f complex/testing-values/values-ingress.yaml
           helm template test ./complex --debug -f complex/testing-values/values-values-from.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,6 +82,9 @@ jobs:
           helm lint complex -f complex/testing-values/values-volume-mounts.yaml
           helm lint complex -f complex/testing-values/values-initcontainers.yaml
           helm lint complex -f complex/testing-values/values-pvc-efs-shared.yaml
+          helm lint complex -f complex/testing-values/values-recreate.yaml
+          helm lint complex -f complex/testing-values/values-host-network.yaml
+          helm lint complex -f complex/testing-values/values-node-name.yaml
 
   template-test:
     runs-on: ubuntu-latest
@@ -123,6 +126,9 @@ jobs:
           helm template test ./complex --debug -f complex/testing-values/values-pod-disruption-budget.yaml
           helm template test ./complex --debug -f complex/testing-values/values-initcontainers.yaml
           helm template test ./complex --debug -f complex/testing-values/values-pvc-efs-shared.yaml
+          helm template test ./complex --debug -f complex/testing-values/values-recreate.yaml
+          helm template test ./complex --debug -f complex/testing-values/values-host-network.yaml
+          helm template test ./complex --debug -f complex/testing-values/values-node-name.yaml
           
           # Test infrastructure configurations
           helm template test ./complex --debug -f complex/testing-values/values-ingress.yaml
@@ -132,6 +138,29 @@ jobs:
           helm template test ./complex --debug -f complex/testing-values/values-configmap.yaml
           helm template test ./complex --debug -f complex/testing-values/values-volume-mounts.yaml
           helm template test ./complex --debug -f complex/testing-values/values-tolerations.yaml
+
+  unit-test:
+    runs-on: ubuntu-latest
+    needs: init
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: '3.13.0'
+
+      - name: Download dependencies
+        uses: actions/download-artifact@v4
+        with:
+          name: helm-dependencies
+          path: complex/charts
+
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version 0.6.2
+
+      - name: Run unit tests
+        run: helm unittest complex
 
   docs-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,7 +157,7 @@ jobs:
           path: complex/charts
 
       - name: Install helm-unittest plugin
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version 0.6.2
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version 1.0.3
 
       - name: Run unit tests
         run: helm unittest complex

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: init
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Helm
         uses: azure/setup-helm@v4

--- a/complex/Chart.yaml
+++ b/complex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: complex
 description: For deploying applications with consumers and cronjobs
 type: application
-version: 1.8.3
+version: 1.8.4
 kubeVersion: ">= 1.25.0-0 < 2.0.0-0"
 
 dependencies:

--- a/complex/README.md
+++ b/complex/README.md
@@ -2,7 +2,7 @@
 
 # complex
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.8.4](https://img.shields.io/badge/Version-1.8.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 For deploying applications, consumers and cronjobs
 
@@ -13,7 +13,6 @@ The **complex** Helm chart provides a comprehensive solution for deploying conta
 - **ConfigMap integration**: Environment variables and file mounting from ConfigMaps
 - **Secret integration**: Environment variables and file mounting from Secrets 
 - **Volume mounts**: Mount ConfigMaps and Secrets as files with custom paths
-- **Persistent storage**: Create new PVCs or reference existing ones for shared storage (EFS)
 - **Consumer workloads**: Support for consumer-type deployments
 - **CronJob support**: Scheduled job execution
 - **Enterprise features**: Immutable ConfigMaps, custom labels/annotations
@@ -222,7 +221,6 @@ Each init container supports the same properties as regular containers:
 | `resources` | CPU/memory requests and limits | No |
 | `volumeMounts` | Mount ConfigMaps or Secrets as files | No |
 
-
 ## Configuration Structure
 
 ### Global vs Component-Specific Configuration
@@ -355,122 +353,6 @@ components:
       secrets: []     # Empty array = no secret volumes
 ```
 
-## Persistent Volume Claims
-
-The chart supports creating PersistentVolumeClaims (PVCs) for components that need persistent storage. You can either create a new PVC or reference an existing one to share storage across multiple pods.
-
-### Creating a New PVC
-
-When `persistentVolumeClaim` is configured without `useExistingClaim`, the chart creates a new PVC for the component:
-
-```yaml
-components:
-  api:
-    type: http
-    persistentVolumeClaim:
-      size: 10Gi
-      accessModes:
-        - ReadWriteOnce
-      storageClassName: standard
-      # Optional: Add custom annotations (e.g., for EFS access points)
-      annotations:
-        efs.csi.aws.com/access-point-id: "fsap-0123456789abcdef0"
-      # Optional: Add custom labels
-      labels:
-        storage-tier: "premium"
-    volumeMounts:
-      others:
-        - name: data
-          mountPath: /app/data
-          readOnly: false
-```
-
-**PVC Properties:**
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `size` | string | `"1Gi"` | Storage size (e.g., "1Gi", "10Gi") |
-| `accessModes` | array | `["ReadWriteOnce"]` | Access modes: `ReadWriteOnce`, `ReadOnlyMany`, `ReadWriteMany`, `ReadWriteOncePod` |
-| `storageClassName` | string | - | Storage class name for the PVC |
-| `annotations` | object | `{}` | Custom annotations (useful for storage-specific configurations) |
-| `labels` | object | `{}` | Custom labels |
-| `selector` | object | - | Label selector for binding to specific PVs |
-| `volumeName` | string | - | Name of the PersistentVolume to bind to |
-
-### Using an Existing PVC
-
-To share storage across multiple pods or reference a PVC created outside the chart, use `useExistingClaim`:
-
-```yaml
-components:
-  api:
-    type: http
-    persistentVolumeClaim:
-      useExistingClaim: true
-      existingClaimName: "shared-storage-pvc"
-    volumeMounts:
-      others:
-        - name: data
-          mountPath: /app/data
-          readOnly: false
-
-  worker:
-    type: consumer
-    persistentVolumeClaim:
-      useExistingClaim: true
-      existingClaimName: "shared-storage-pvc"  # Same PVC as api component
-    volumeMounts:
-      others:
-        - name: data
-          mountPath: /data
-          readOnly: false
-```
-
-**Benefits of Using Existing PVCs:**
-
-- **Shared storage**: Multiple pods can mount the same PVC (requires `ReadWriteMany` access mode)
-- **Pre-existing storage**: Reference PVCs created manually or by other charts
-- **Storage reuse**: Avoid creating duplicate PVCs for the same storage
-
-**Important Notes:**
-
-- When `useExistingClaim: true`, the chart does **not** create a PVC - it only references the existing one
-- The existing PVC must already exist in the same namespace
-- Ensure the PVC's access mode supports your use case (e.g., `ReadWriteMany` for multi-pod access)
-
-### Complete Example
-
-```yaml
-components:
-  # Component that creates a new PVC
-  web:
-    type: http
-    persistentVolumeClaim:
-      size: 5Gi
-      accessModes:
-        - ReadWriteMany  # Allows multiple pods to mount
-      storageClassName: efs-sc
-      annotations:
-        efs.csi.aws.com/access-point-id: "fsap-0123456789abcdef0"
-    volumeMounts:
-      others:
-        - name: data
-          mountPath: /usr/share/nginx/html
-
-  # Component that uses the existing PVC created above
-  api:
-    type: http
-    persistentVolumeClaim:
-      useExistingClaim: true
-      existingClaimName: "my-release-web"  # References the PVC created by web component
-    volumeMounts:
-      others:
-        - name: data
-          mountPath: /app/data
-```
-
-See `testing-values/values-pvc.yaml` and `testing-values/values-pvc-efs-shared.yaml` for more examples.
-
 ## Installation
 
 ```bash
@@ -561,8 +443,6 @@ The following complete configuration examples are available in the `testing-valu
 - [`values-minimal.yaml`](testing-values/values-minimal.yaml) - Basic HTTP service
 - [`values-configmap.yaml`](testing-values/values-configmap.yaml) - ConfigMap integration
 - [`values-volume-mounts.yaml`](testing-values/values-volume-mounts.yaml) - Volume mount examples
-- [`values-pvc.yaml`](testing-values/values-pvc.yaml) - PersistentVolumeClaim examples
-- [`values-pvc-efs-shared.yaml`](testing-values/values-pvc-efs-shared.yaml) - Shared storage with existing PVCs
 - [`values-consumer.yaml`](testing-values/values-consumer.yaml) - Consumer workloads
 - [`values-cronjob.yaml`](testing-values/values-cronjob.yaml) - Scheduled jobs
 - [`values-hpa.yaml`](testing-values/values-hpa.yaml) - Auto-scaling configuration

--- a/complex/README.md
+++ b/complex/README.md
@@ -13,6 +13,7 @@ The **complex** Helm chart provides a comprehensive solution for deploying conta
 - **ConfigMap integration**: Environment variables and file mounting from ConfigMaps
 - **Secret integration**: Environment variables and file mounting from Secrets 
 - **Volume mounts**: Mount ConfigMaps and Secrets as files with custom paths
+- **Persistent storage**: Create new PVCs or reference existing ones for shared storage (EFS)
 - **Consumer workloads**: Support for consumer-type deployments
 - **CronJob support**: Scheduled job execution
 - **Enterprise features**: Immutable ConfigMaps, custom labels/annotations
@@ -353,6 +354,122 @@ components:
       secrets: []     # Empty array = no secret volumes
 ```
 
+## Persistent Volume Claims
+
+The chart supports creating PersistentVolumeClaims (PVCs) for components that need persistent storage. You can either create a new PVC or reference an existing one to share storage across multiple pods.
+
+### Creating a New PVC
+
+When `persistentVolumeClaim` is configured without `useExistingClaim`, the chart creates a new PVC for the component:
+
+```yaml
+components:
+  api:
+    type: http
+    persistentVolumeClaim:
+      size: 10Gi
+      accessModes:
+        - ReadWriteOnce
+      storageClassName: standard
+      # Optional: Add custom annotations (e.g., for EFS access points)
+      annotations:
+        efs.csi.aws.com/access-point-id: "fsap-0123456789abcdef0"
+      # Optional: Add custom labels
+      labels:
+        storage-tier: "premium"
+    volumeMounts:
+      others:
+        - name: data
+          mountPath: /app/data
+          readOnly: false
+```
+
+**PVC Properties:**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `size` | string | `"1Gi"` | Storage size (e.g., "1Gi", "10Gi") |
+| `accessModes` | array | `["ReadWriteOnce"]` | Access modes: `ReadWriteOnce`, `ReadOnlyMany`, `ReadWriteMany`, `ReadWriteOncePod` |
+| `storageClassName` | string | - | Storage class name for the PVC |
+| `annotations` | object | `{}` | Custom annotations (useful for storage-specific configurations) |
+| `labels` | object | `{}` | Custom labels |
+| `selector` | object | - | Label selector for binding to specific PVs |
+| `volumeName` | string | - | Name of the PersistentVolume to bind to |
+
+### Using an Existing PVC
+
+To share storage across multiple pods or reference a PVC created outside the chart, use `useExistingClaim`:
+
+```yaml
+components:
+  api:
+    type: http
+    persistentVolumeClaim:
+      useExistingClaim: true
+      existingClaimName: "shared-storage-pvc"
+    volumeMounts:
+      others:
+        - name: data
+          mountPath: /app/data
+          readOnly: false
+
+  worker:
+    type: consumer
+    persistentVolumeClaim:
+      useExistingClaim: true
+      existingClaimName: "shared-storage-pvc"  # Same PVC as api component
+    volumeMounts:
+      others:
+        - name: data
+          mountPath: /data
+          readOnly: false
+```
+
+**Benefits of Using Existing PVCs:**
+
+- **Shared storage**: Multiple pods can mount the same PVC (requires `ReadWriteMany` access mode)
+- **Pre-existing storage**: Reference PVCs created manually or by other charts
+- **Storage reuse**: Avoid creating duplicate PVCs for the same storage
+
+**Important Notes:**
+
+- When `useExistingClaim: true`, the chart does **not** create a PVC - it only references the existing one
+- The existing PVC must already exist in the same namespace
+- Ensure the PVC's access mode supports your use case (e.g., `ReadWriteMany` for multi-pod access)
+
+### Complete Example
+
+```yaml
+components:
+  # Component that creates a new PVC
+  web:
+    type: http
+    persistentVolumeClaim:
+      size: 5Gi
+      accessModes:
+        - ReadWriteMany  # Allows multiple pods to mount
+      storageClassName: efs-sc
+      annotations:
+        efs.csi.aws.com/access-point-id: "fsap-0123456789abcdef0"
+    volumeMounts:
+      others:
+        - name: data
+          mountPath: /usr/share/nginx/html
+
+  # Component that uses the existing PVC created above
+  api:
+    type: http
+    persistentVolumeClaim:
+      useExistingClaim: true
+      existingClaimName: "my-release-web"  # References the PVC created by web component
+    volumeMounts:
+      others:
+        - name: data
+          mountPath: /app/data
+```
+
+See `testing-values/values-pvc.yaml` and `testing-values/values-pvc-efs-shared.yaml` for more examples.
+
 ## Installation
 
 ```bash
@@ -443,6 +560,8 @@ The following complete configuration examples are available in the `testing-valu
 - [`values-minimal.yaml`](testing-values/values-minimal.yaml) - Basic HTTP service
 - [`values-configmap.yaml`](testing-values/values-configmap.yaml) - ConfigMap integration
 - [`values-volume-mounts.yaml`](testing-values/values-volume-mounts.yaml) - Volume mount examples
+- [`values-pvc.yaml`](testing-values/values-pvc.yaml) - PersistentVolumeClaim examples
+- [`values-pvc-efs-shared.yaml`](testing-values/values-pvc-efs-shared.yaml) - Shared storage with existing PVCs
 - [`values-consumer.yaml`](testing-values/values-consumer.yaml) - Consumer workloads
 - [`values-cronjob.yaml`](testing-values/values-cronjob.yaml) - Scheduled jobs
 - [`values-hpa.yaml`](testing-values/values-hpa.yaml) - Auto-scaling configuration

--- a/complex/README.md.gotmpl
+++ b/complex/README.md.gotmpl
@@ -15,6 +15,7 @@ The **complex** Helm chart provides a comprehensive solution for deploying conta
 - **ConfigMap integration**: Environment variables and file mounting from ConfigMaps
 - **Secret integration**: Environment variables and file mounting from Secrets  
 - **Volume mounts**: Mount ConfigMaps and Secrets as files with custom paths
+- **Persistent storage**: Create new PVCs or reference existing ones for shared storage (EFS)
 - **Consumer workloads**: Support for consumer-type deployments
 - **CronJob support**: Scheduled job execution
 - **Enterprise features**: Immutable ConfigMaps, custom labels/annotations
@@ -355,6 +356,122 @@ components:
       secrets: []     # Empty array = no secret volumes
 ```
 
+## Persistent Volume Claims
+
+The chart supports creating PersistentVolumeClaims (PVCs) for components that need persistent storage. You can either create a new PVC or reference an existing one to share storage across multiple pods.
+
+### Creating a New PVC
+
+When `persistentVolumeClaim` is configured without `useExistingClaim`, the chart creates a new PVC for the component:
+
+```yaml
+components:
+  api:
+    type: http
+    persistentVolumeClaim:
+      size: 10Gi
+      accessModes:
+        - ReadWriteOnce
+      storageClassName: standard
+      # Optional: Add custom annotations (e.g., for EFS access points)
+      annotations:
+        efs.csi.aws.com/access-point-id: "fsap-0123456789abcdef0"
+      # Optional: Add custom labels
+      labels:
+        storage-tier: "premium"
+    volumeMounts:
+      others:
+        - name: data
+          mountPath: /app/data
+          readOnly: false
+```
+
+**PVC Properties:**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `size` | string | `"1Gi"` | Storage size (e.g., "1Gi", "10Gi") |
+| `accessModes` | array | `["ReadWriteOnce"]` | Access modes: `ReadWriteOnce`, `ReadOnlyMany`, `ReadWriteMany`, `ReadWriteOncePod` |
+| `storageClassName` | string | - | Storage class name for the PVC |
+| `annotations` | object | `{}` | Custom annotations (useful for storage-specific configurations) |
+| `labels` | object | `{}` | Custom labels |
+| `selector` | object | - | Label selector for binding to specific PVs |
+| `volumeName` | string | - | Name of the PersistentVolume to bind to |
+
+### Using an Existing PVC
+
+To share storage across multiple pods or reference a PVC created outside the chart, use `useExistingClaim`:
+
+```yaml
+components:
+  api:
+    type: http
+    persistentVolumeClaim:
+      useExistingClaim: true
+      existingClaimName: "shared-storage-pvc"
+    volumeMounts:
+      others:
+        - name: data
+          mountPath: /app/data
+          readOnly: false
+
+  worker:
+    type: consumer
+    persistentVolumeClaim:
+      useExistingClaim: true
+      existingClaimName: "shared-storage-pvc"  # Same PVC as api component
+    volumeMounts:
+      others:
+        - name: data
+          mountPath: /data
+          readOnly: false
+```
+
+**Benefits of Using Existing PVCs:**
+
+- **Shared storage**: Multiple pods can mount the same PVC (requires `ReadWriteMany` access mode)
+- **Pre-existing storage**: Reference PVCs created manually or by other charts
+- **Storage reuse**: Avoid creating duplicate PVCs for the same storage
+
+**Important Notes:**
+
+- When `useExistingClaim: true`, the chart does **not** create a PVC - it only references the existing one
+- The existing PVC must already exist in the same namespace
+- Ensure the PVC's access mode supports your use case (e.g., `ReadWriteMany` for multi-pod access)
+
+### Complete Example
+
+```yaml
+components:
+  # Component that creates a new PVC
+  web:
+    type: http
+    persistentVolumeClaim:
+      size: 5Gi
+      accessModes:
+        - ReadWriteMany  # Allows multiple pods to mount
+      storageClassName: efs-sc
+      annotations:
+        efs.csi.aws.com/access-point-id: "fsap-0123456789abcdef0"
+    volumeMounts:
+      others:
+        - name: data
+          mountPath: /usr/share/nginx/html
+
+  # Component that uses the existing PVC created above
+  api:
+    type: http
+    persistentVolumeClaim:
+      useExistingClaim: true
+      existingClaimName: "my-release-web"  # References the PVC created by web component
+    volumeMounts:
+      others:
+        - name: data
+          mountPath: /app/data
+```
+
+See `testing-values/values-pvc.yaml` and `testing-values/values-pvc-efs-shared.yaml` for more examples.
+
 ## Installation
 
 ```bash
@@ -445,6 +562,8 @@ The following complete configuration examples are available in the `testing-valu
 - [`values-minimal.yaml`](testing-values/values-minimal.yaml) - Basic HTTP service
 - [`values-configmap.yaml`](testing-values/values-configmap.yaml) - ConfigMap integration
 - [`values-volume-mounts.yaml`](testing-values/values-volume-mounts.yaml) - Volume mount examples
+- [`values-pvc.yaml`](testing-values/values-pvc.yaml) - PersistentVolumeClaim examples
+- [`values-pvc-efs-shared.yaml`](testing-values/values-pvc-efs-shared.yaml) - Shared storage with existing PVCs
 - [`values-consumer.yaml`](testing-values/values-consumer.yaml) - Consumer workloads
 - [`values-cronjob.yaml`](testing-values/values-cronjob.yaml) - Scheduled jobs
 - [`values-hpa.yaml`](testing-values/values-hpa.yaml) - Auto-scaling configuration

--- a/complex/templates/_container.tpl
+++ b/complex/templates/_container.tpl
@@ -50,7 +50,7 @@ volumeMounts:
 {{- range . }}
   - name: {{ .name }}
     mountPath: {{ .mountPath }}
-    readOnly: {{ .readOnly | default true }}
+    readOnly: {{ ne .readOnly false }}
     {{- if .subPath }}
     subPath: {{ .subPath }}
     {{- end }}
@@ -60,7 +60,7 @@ volumeMounts:
 {{- range . }}
   - name: {{ .name }}
     mountPath: {{ .mountPath }}
-    readOnly: {{ .readOnly | default true }}
+    readOnly: {{ ne .readOnly false }}
     {{- if .subPath }}
     subPath: {{ .subPath }}
     {{- end }}

--- a/complex/templates/deployment.yaml
+++ b/complex/templates/deployment.yaml
@@ -20,16 +20,13 @@ metadata:
 spec:
   replicas: {{ $component.replicas }}
   progressDeadlineSeconds: {{ default 300 $component.progressDeadlineSeconds }}
-  {{- if eq (default "RollingUpdate" $component.strategyType) "Recreate" }}
   strategy:
-    type: Recreate
-  {{- else }}
-  strategy:
-    type: RollingUpdate
+    type: {{ default "RollingUpdate" $component.strategyType }}
+    {{- if ne (default "RollingUpdate" $component.strategyType) "Recreate" }}
     rollingUpdate:
       maxUnavailable: {{ coalesce (index $component "rollingUpdate" | default dict).maxUnavailable $.Values.global.rollingUpdate.maxUnavailable | quote}}
       maxSurge: {{ coalesce (index $component "rollingUpdate" | default dict).maxSurge $.Values.global.rollingUpdate.maxSurge | quote}}
-  {{- end }}
+    {{- end }}
   selector:
     matchLabels:
       {{ include "cookielab.kubernetes.labels.selector" $kubeLabels | indent 6 | trim }}

--- a/complex/templates/keda-scaledobject.yaml
+++ b/complex/templates/keda-scaledobject.yaml
@@ -18,7 +18,7 @@ spec:
   triggers:
   {{- range $i, $trigger := $keda.triggers }}
     {{- if eq $trigger.type "kafka" }}
-      {{- $awsRegion := $trigger.awsRegion | default $.Values.global.keda.awsRegion }}
+      {{- $awsRegion := $trigger.awsRegion | default ($.Values.global.keda).awsRegion }}
       {{- if (not $awsRegion) }}
         {{- fail (printf "Kafka trigger for '%s' is missing required field(s)." $componentName) }}
       {{- end }}
@@ -41,7 +41,7 @@ spec:
         {{- end }}
 
     {{- else if eq $trigger.type "aws-sqs-queue" }}
-      {{- $awsRegion := $trigger.awsRegion | default $.Values.global.keda.awsRegion }}
+      {{- $awsRegion := $trigger.awsRegion | default ($.Values.global.keda).awsRegion }}
       {{- if (not $awsRegion) }}
         {{- fail (printf "SQS trigger for '%s' is missing required field(s)." $componentName) }}
       {{- end }}

--- a/complex/templates/keda-triggerauthentication.yaml
+++ b/complex/templates/keda-triggerauthentication.yaml
@@ -2,7 +2,7 @@
   {{- if and (eq $component.type "consumer") (hasKey $component "keda") }}
     {{- $name := include "component.name" (dict "name" $componentName "Release" $.Release) }}
     {{- range $i, $trigger := $component.keda.triggers }}
-      {{- if and (eq $trigger.type "aws-sqs-queue") (ne (default "operator" $trigger.identityOwner) "operator") (default true $trigger.triggerAuthEnabled) }}
+      {{- if and (eq $trigger.type "aws-sqs-queue") (ne (default "operator" $trigger.identityOwner) "operator") (ne $trigger.triggerAuthEnabled false) }}
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication

--- a/complex/templates/serviceaccount.yaml
+++ b/complex/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 {{- if and (ne $component.type "cronjob") (ne $component.type "pre-job") (ne $component.type "ingress") -}}
 {{- $kubeLabels := (merge (dict "name" $.Release.Name "instance" (printf "%s-%d" (include "component.name" (dict "name" $componentName "Release" $.Release)) $.Release.Revision) "component" $componentName) $.Values.global.metadata) -}}
 {{- if and $component.serviceAccountCreate $component.serviceAccountName }}
---
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -16,7 +16,7 @@ metadata:
 {{- end }}
 {{- end }}
 
-{{- if and .Values.global.serviceAccountCreate -}}
+{{- if and .Values.global.serviceAccountCreate }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/complex/templates/serviceaccount.yaml
+++ b/complex/templates/serviceaccount.yaml
@@ -16,7 +16,7 @@ metadata:
 {{- end }}
 {{- end }}
 
-{{- if and .Values.global.serviceAccountCreate }}
+{{- if .Values.global.serviceAccountCreate }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/complex/testing-values/values-host-network.yaml
+++ b/complex/testing-values/values-host-network.yaml
@@ -1,0 +1,44 @@
+global:
+  container:
+    image:
+      repository: cookielab/deployer
+      tag: 1.0.0-rc2
+
+components:
+  edge:
+    type: http
+    replicas: 1
+    hostNetwork: true
+    dnsPolicy: ClusterFirstWithHostNet
+    strategyType: Recreate
+    ports:
+      - port: 8443
+    probes:
+      readinessProbe:
+        httpGet:
+          port: 8443
+          path: /health-check
+          scheme: HTTPS
+      livenessProbe:
+        httpGet:
+          port: 8443
+          path: /health-check
+          scheme: HTTPS
+    targetGroup:
+      arn: 'arn:fake'
+      securityGroupIds:
+        - sg-fake
+  worker-on-host:
+    type: consumer
+    replicas: 1
+    hostNetwork: true
+    dnsPolicy: ClusterFirstWithHostNet
+    command:
+      - bin/consume
+  scheduled-host-task:
+    type: cronjob
+    schedule: "*/5 * * * *"
+    hostNetwork: true
+    dnsPolicy: ClusterFirstWithHostNet
+    command:
+      - bin/cron-task

--- a/complex/testing-values/values-node-name.yaml
+++ b/complex/testing-values/values-node-name.yaml
@@ -1,0 +1,43 @@
+global:
+  container:
+    image:
+      repository: cookielab/deployer
+      tag: 1.0.0-rc2
+
+components:
+  api:
+    type: http
+    replicas: 1
+    nodeName: ip-10-0-0-1.ec2.internal
+    ports:
+      - port: 3000
+    probes:
+      readinessProbe:
+        httpGet:
+          port: 8080
+          path: /health-check
+      livenessProbe:
+        httpGet:
+          port: 8080
+          path: /health-check
+    targetGroup:
+      arn: 'arn:fake'
+      securityGroupIds:
+        - sg-fake
+  pinned-worker:
+    type: consumer
+    replicas: 1
+    nodeName: ip-10-0-0-2.ec2.internal
+    command:
+      - bin/consume
+  pinned-cron:
+    type: cronjob
+    schedule: "0 * * * *"
+    nodeName: ip-10-0-0-3.ec2.internal
+    command:
+      - bin/cron-task
+  pinned-pre-job:
+    type: pre-job
+    nodeName: ip-10-0-0-4.ec2.internal
+    command:
+      - bin/migrate

--- a/complex/testing-values/values-recreate.yaml
+++ b/complex/testing-values/values-recreate.yaml
@@ -1,0 +1,41 @@
+global:
+  container:
+    image:
+      repository: cookielab/deployer
+      tag: 1.0.0-rc2
+
+components:
+  api:
+    type: http
+    replicas: 1
+    strategyType: Recreate
+    ports:
+      - port: 3000
+    probes:
+      readinessProbe:
+        httpGet:
+          port: 8080
+          path: /health-check
+        periodSeconds: 30
+        timeoutSeconds: 15
+      livenessProbe:
+        httpGet:
+          port: 8080
+          path: /health-check
+    targetGroup:
+      arn: 'arn:fake'
+      securityGroupIds:
+        - sg-fake
+  worker:
+    type: consumer
+    strategyType: Recreate
+    command:
+      - bin/consume
+  rolling-worker:
+    type: consumer
+    strategyType: RollingUpdate
+    command:
+      - bin/consume
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%

--- a/complex/tests/configmap_test.yaml
+++ b/complex/tests/configmap_test.yaml
@@ -1,0 +1,149 @@
+suite: ConfigMap rendering and tpl substitution
+release:
+  name: test
+  namespace: default
+templates:
+  - templates/configmap.yaml
+values:
+  - ../testing-values/values-minimal.yaml
+tests:
+  - it: does not render any ConfigMap when configMaps is unset
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders one ConfigMap per configMaps entry
+    set:
+      configMaps:
+        app-config:
+          data:
+            LOG_LEVEL: info
+        shared-config:
+          data:
+            FEATURE_X: "true"
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: ConfigMap
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: app-config
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: shared-config
+        documentIndex: 1
+
+  - it: emits standard kubernetes labels with component=config
+    set:
+      configMaps:
+        app-config:
+          data:
+            LOG_LEVEL: info
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: config
+      - equal:
+          path: metadata.namespace
+          value: default
+
+  - it: merges custom labels with defaults
+    set:
+      configMaps:
+        app-config:
+          labels:
+            config-type: application
+            environment: testing
+          data:
+            X: "1"
+    asserts:
+      - equal:
+          path: metadata.labels["config-type"]
+          value: application
+      - equal:
+          path: metadata.labels["environment"]
+          value: testing
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: config
+
+  - it: emits annotations only when provided
+    set:
+      configMaps:
+        app-config:
+          annotations:
+            config.kubernetes.io/source: helm
+          data:
+            X: "1"
+    asserts:
+      - equal:
+          path: metadata.annotations["config.kubernetes.io/source"]
+          value: helm
+
+  - it: omits annotations when none are provided
+    set:
+      configMaps:
+        app-config:
+          data:
+            X: "1"
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: marks ConfigMap immutable when requested
+    set:
+      configMaps:
+        app-config:
+          immutable: true
+          data:
+            X: "1"
+    asserts:
+      - equal:
+          path: immutable
+          value: true
+
+  - it: omits immutable field when not set
+    set:
+      configMaps:
+        app-config:
+          data:
+            X: "1"
+    asserts:
+      - notExists:
+          path: immutable
+
+  - it: substitutes Release.Name through tpl in data values
+    set:
+      configMaps:
+        app-config:
+          data:
+            APP_NAME: "{{ .Release.Name }}"
+    asserts:
+      - equal:
+          path: data.APP_NAME
+          value: test
+
+  - it: renders multiple data keys
+    set:
+      configMaps:
+        app-config:
+          data:
+            DATABASE_URL: postgresql://localhost:5432/myapp
+            REDIS_URL: redis://localhost:6379
+            LOG_LEVEL: info
+    asserts:
+      - equal:
+          path: data.DATABASE_URL
+          value: postgresql://localhost:5432/myapp
+      - equal:
+          path: data.REDIS_URL
+          value: redis://localhost:6379
+      - equal:
+          path: data.LOG_LEVEL
+          value: info

--- a/complex/tests/cronjob_and_prejob_test.yaml
+++ b/complex/tests/cronjob_and_prejob_test.yaml
@@ -1,0 +1,151 @@
+suite: CronJob and pre-job (Job) rendering details
+release:
+  name: test
+set:
+  global.container.image.repository: cookielab/deployer
+  global.container.image.tag: 1.0.0-rc2
+tests:
+  - it: renders CronJob with schedule and Forbid concurrency policy
+    templates:
+      - templates/cronJob.yaml
+    set:
+      components.cron.type: cronjob
+      components.cron.schedule: "*/5 * * * *"
+      components.cron.command:
+        - bin/task
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: apiVersion
+          value: batch/v1
+      - equal:
+          path: metadata.name
+          value: test-cron
+      - equal:
+          path: spec.schedule
+          value: "*/5 * * * *"
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Forbid
+
+  - it: defaults suspend to false
+    templates:
+      - templates/cronJob.yaml
+    set:
+      components.cron.type: cronjob
+      components.cron.schedule: "0 * * * *"
+      components.cron.command:
+        - bin/task
+    asserts:
+      - equal:
+          path: spec.suspend
+          value: false
+
+  - it: honours suspend true
+    templates:
+      - templates/cronJob.yaml
+    set:
+      components.cron.type: cronjob
+      components.cron.schedule: "0 * * * *"
+      components.cron.command:
+        - bin/task
+      components.cron.suspend: true
+    asserts:
+      - equal:
+          path: spec.suspend
+          value: true
+
+  - it: sets backoffLimit on inner Job template to 3
+    templates:
+      - templates/cronJob.yaml
+    set:
+      components.cron.type: cronjob
+      components.cron.schedule: "0 * * * *"
+      components.cron.command:
+        - bin/task
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.backoffLimit
+          value: 3
+
+  - it: does not render CronJob for non-cronjob component types
+    templates:
+      - templates/cronJob.yaml
+    values:
+      - ../testing-values/values-minimal.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders pre-job as Job with helm hooks
+    templates:
+      - templates/job.yaml
+    set:
+      components.migrate.type: pre-job
+      components.migrate.command:
+        - bin/migrate
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: apiVersion
+          value: batch/v1
+      - equal:
+          path: metadata.name
+          value: test-migrate
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation
+
+  - it: defaults pre-job hook-weight to 0 when not set
+    templates:
+      - templates/job.yaml
+    set:
+      components.migrate.type: pre-job
+      components.migrate.command:
+        - bin/migrate
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "0"
+
+  - it: honours pre-job hook-weight when set
+    templates:
+      - templates/job.yaml
+    set:
+      components.migrate.type: pre-job
+      components.migrate.command:
+        - bin/migrate
+      components.migrate.weight: 5
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "5"
+
+  - it: pre-job has restartPolicy Never and backoffLimit 0
+    templates:
+      - templates/job.yaml
+    set:
+      components.migrate.type: pre-job
+      components.migrate.command:
+        - bin/migrate
+    asserts:
+      - equal:
+          path: spec.template.spec.restartPolicy
+          value: Never
+      - equal:
+          path: spec.backoffLimit
+          value: 0
+
+  - it: does not render Job for non-pre-job component types
+    templates:
+      - templates/job.yaml
+    values:
+      - ../testing-values/values-minimal.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/complex/tests/deployment_core_test.yaml
+++ b/complex/tests/deployment_core_test.yaml
@@ -1,0 +1,335 @@
+suite: Deployment core rendering
+templates:
+  - templates/deployment.yaml
+release:
+  name: test
+values:
+  - ../testing-values/values-minimal.yaml
+tests:
+  - it: propagates replicas from the component
+    set:
+      components.api.replicas: 5
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 5
+
+  - it: defaults progressDeadlineSeconds to 300
+    asserts:
+      - equal:
+          path: spec.progressDeadlineSeconds
+          value: 300
+
+  - it: honours an explicit progressDeadlineSeconds
+    set:
+      components.api.progressDeadlineSeconds: 600
+    asserts:
+      - equal:
+          path: spec.progressDeadlineSeconds
+          value: 600
+
+  - it: renders container image from global container settings
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: application
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: cookielab/deployer:1.0.0-rc2
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
+  - it: allows component-level image override
+    set:
+      components.api.image:
+        repository: my/app
+        tag: v2.3.4
+        pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: my/app:v2.3.4
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+
+  - it: renders command and args when set on the component
+    set:
+      components.api.command:
+        - /bin/sh
+        - -c
+      components.api.args:
+        - exec /app/server
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /bin/sh
+            - -c
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - exec /app/server
+
+  - it: omits command and args when not set
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].command
+      - notExists:
+          path: spec.template.spec.containers[0].args
+
+  - it: renders ports as containerPort entries
+    set:
+      components.api.ports:
+        - name: http
+          port: 8080
+        - port: 9090
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8080
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].name
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].containerPort
+          value: 9090
+
+  - it: renders literal env values from envs.values
+    set:
+      components.api.envs.values:
+        FOO: bar
+        DEBUG: "true"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FOO
+            value: "bar"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEBUG
+            value: "true"
+
+  - it: renders env valueFrom for fieldRef short-form string
+    set:
+      components.api.envs.valuesFrom:
+        POD_NAME: metadata.name
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: "metadata.name"
+
+  - it: renders env valueFrom for secretKeyRef
+    set:
+      components.api.envs.valuesFrom:
+        DB_PASSWORD:
+          secretKeyRef:
+            name: db-secret
+            key: password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "db-secret"
+                key: "password"
+
+  - it: renders envFrom for secretRef and configMapRef
+    set:
+      components.api.envs.from:
+        secrets:
+          - app-secret
+        configMaps:
+          - app-config
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: app-secret
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: app-config
+
+  - it: inherits resources from global container settings
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 200m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 256M
+
+  - it: allows component-level resources override
+    set:
+      components.api.resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+          ephemeralStorage: 2Gi
+        requests:
+          cpu: 250m
+          memory: 256Mi
+          ephemeralStorage: 1Gi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 500m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 512Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 250m
+
+  - it: renders liveness, readiness and startup probes
+    set:
+      components.api.probes:
+        livenessProbe:
+          httpGet:
+            port: 8080
+            path: /alive
+        readinessProbe:
+          httpGet:
+            port: 8080
+            path: /ready
+        startupProbe:
+          httpGet:
+            port: 8080
+            path: /startup
+          failureThreshold: 30
+          periodSeconds: 10
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /alive
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /ready
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /startup
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 30
+
+  - it: defaults restartPolicy to Always and terminationGracePeriodSeconds to 120
+    asserts:
+      - equal:
+          path: spec.template.spec.restartPolicy
+          value: Always
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 120
+
+  - it: defaults enableServiceLinks to False
+    asserts:
+      - equal:
+          path: spec.template.spec.enableServiceLinks
+          value: False
+
+  - it: honours enableServiceLinks True override
+    set:
+      components.api.enableServiceLinks: True
+    asserts:
+      - equal:
+          path: spec.template.spec.enableServiceLinks
+          value: True
+
+  - it: renders global imagePullSecrets on the pod spec
+    set:
+      global.imagePullSecrets:
+        - my-registry-auth
+        - shared-registry
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: my-registry-auth
+      - equal:
+          path: spec.template.spec.imagePullSecrets[1].name
+          value: shared-registry
+
+  - it: component-level imagePullSecrets overrides global
+    set:
+      global.imagePullSecrets:
+        - global-auth
+      components.api.imagePullSecrets:
+        - api-only-auth
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: api-only-auth
+      - lengthEqual:
+          path: spec.template.spec.imagePullSecrets
+          count: 1
+
+  - it: omits imagePullSecrets when neither global nor component sets them
+    asserts:
+      - notExists:
+          path: spec.template.spec.imagePullSecrets
+
+  - it: renders tolerations from the component
+    set:
+      components.api.tolerations:
+        - key: dedicated
+          operator: Equal
+          value: gpu
+          effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations[0].key
+          value: dedicated
+      - equal:
+          path: spec.template.spec.tolerations[0].operator
+          value: Equal
+      - equal:
+          path: spec.template.spec.tolerations[0].value
+          value: gpu
+      - equal:
+          path: spec.template.spec.tolerations[0].effect
+          value: NoSchedule
+
+  - it: omits tolerations when none configured
+    asserts:
+      - notExists:
+          path: spec.template.spec.tolerations
+
+  - it: merges global and component nodeSelector
+    set:
+      global.nodeSelector:
+        kubernetes.io/os: linux
+      components.api.nodeSelector:
+        node-pool: workers
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector["kubernetes.io/os"]
+          value: linux
+      - equal:
+          path: spec.template.spec.nodeSelector["node-pool"]
+          value: workers
+
+  - it: selector matchLabels match the pod template labels
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: api
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: test
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: api
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: test

--- a/complex/tests/host_network_test.yaml
+++ b/complex/tests/host_network_test.yaml
@@ -1,0 +1,88 @@
+suite: hostNetwork and dnsPolicy
+release:
+  name: test
+values:
+  - ../testing-values/values-minimal.yaml
+tests:
+  - it: omits hostNetwork and dnsPolicy by default
+    templates:
+      - templates/deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostNetwork
+      - notExists:
+          path: spec.template.spec.dnsPolicy
+
+  - it: sets hostNetwork on Deployment pod spec
+    templates:
+      - templates/deployment.yaml
+    set:
+      components.api.hostNetwork: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+
+  - it: sets dnsPolicy on Deployment pod spec
+    templates:
+      - templates/deployment.yaml
+    set:
+      components.api.dnsPolicy: ClusterFirstWithHostNet
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirstWithHostNet
+
+  - it: combines hostNetwork + dnsPolicy on consumer Deployment
+    templates:
+      - templates/deployment.yaml
+    set:
+      components.worker.type: consumer
+      components.worker.command:
+        - bin/consume
+      components.worker.hostNetwork: true
+      components.worker.dnsPolicy: ClusterFirstWithHostNet
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+        documentIndex: 1
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirstWithHostNet
+        documentIndex: 1
+
+  - it: propagates hostNetwork and dnsPolicy to CronJob pod spec
+    templates:
+      - templates/cronJob.yaml
+    set:
+      components.cron.type: cronjob
+      components.cron.schedule: "*/5 * * * *"
+      components.cron.command:
+        - bin/cron-task
+      components.cron.hostNetwork: true
+      components.cron.dnsPolicy: ClusterFirstWithHostNet
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.hostNetwork
+          value: true
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.dnsPolicy
+          value: ClusterFirstWithHostNet
+
+  - it: propagates hostNetwork and dnsPolicy to pre-job pod spec
+    templates:
+      - templates/job.yaml
+    set:
+      components.migrate.type: pre-job
+      components.migrate.command:
+        - bin/migrate
+      components.migrate.hostNetwork: true
+      components.migrate.dnsPolicy: ClusterFirstWithHostNet
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirstWithHostNet

--- a/complex/tests/hpa_test.yaml
+++ b/complex/tests/hpa_test.yaml
@@ -1,0 +1,122 @@
+suite: HorizontalPodAutoscaler rendering
+release:
+  name: test
+templates:
+  - templates/hpa.yaml
+values:
+  - ../testing-values/values-minimal.yaml
+tests:
+  - it: does not render an HPA when hpa is unset
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders an HPA targeting the component Deployment
+    set:
+      components.api.hpa.enabled: true
+      components.api.hpa.minReplicas: 2
+      components.api.hpa.maxReplicas: 10
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: apiVersion
+          value: autoscaling/v2
+      - equal:
+          path: metadata.name
+          value: test-api
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: Deployment
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: test-api
+      - equal:
+          path: spec.minReplicas
+          value: 2
+      - equal:
+          path: spec.maxReplicas
+          value: 10
+
+  - it: defaults minReplicas to component replicas when not set
+    set:
+      components.api.replicas: 4
+      components.api.hpa.enabled: true
+      components.api.hpa.maxReplicas: 10
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 4
+
+  - it: defaults CPU and memory utilization thresholds to 75
+    set:
+      components.api.hpa.enabled: true
+      components.api.hpa.maxReplicas: 5
+    asserts:
+      - equal:
+          path: spec.metrics[0].resource.name
+          value: cpu
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 75
+      - equal:
+          path: spec.metrics[1].resource.name
+          value: memory
+      - equal:
+          path: spec.metrics[1].resource.target.averageUtilization
+          value: 75
+
+  - it: honours custom CPU and memory thresholds
+    set:
+      components.api.hpa.enabled: true
+      components.api.hpa.maxReplicas: 5
+      components.api.hpa.cpuThresholdPercent: 60
+      components.api.hpa.memThresholdPercent: 80
+    asserts:
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 60
+      - equal:
+          path: spec.metrics[1].resource.target.averageUtilization
+          value: 80
+
+  - it: defaults scaleUp window to 0 and scaleDown window to 300
+    set:
+      components.api.hpa.enabled: true
+      components.api.hpa.maxReplicas: 5
+    asserts:
+      - equal:
+          path: spec.behavior.scaleUp.stabilizationWindowSeconds
+          value: 0
+      - equal:
+          path: spec.behavior.scaleDown.stabilizationWindowSeconds
+          value: 300
+
+  - it: honours custom stabilization windows
+    set:
+      components.api.hpa.enabled: true
+      components.api.hpa.maxReplicas: 5
+      components.api.hpa.scaleUp.stabilizationWindowSeconds: 120
+      components.api.hpa.scaleDown.stabilizationWindowSeconds: 600
+    asserts:
+      - equal:
+          path: spec.behavior.scaleUp.stabilizationWindowSeconds
+          value: 120
+      - equal:
+          path: spec.behavior.scaleDown.stabilizationWindowSeconds
+          value: 600
+
+  - it: renders HPA for consumer components
+    set:
+      components.worker.type: consumer
+      components.worker.command:
+        - bin/consume
+      components.worker.replicas: 1
+      components.worker.hpa.enabled: true
+      components.worker.hpa.maxReplicas: 5
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: metadata.name
+          value: test-worker

--- a/complex/tests/ingress_component_test.yaml
+++ b/complex/tests/ingress_component_test.yaml
@@ -1,0 +1,168 @@
+suite: standalone ingress component type
+release:
+  name: test
+set:
+  global.container.image.repository: nginx
+  global.container.image.tag: latest
+tests:
+  - it: ingress-only component does not produce a Deployment
+    templates:
+      - templates/deployment.yaml
+    set:
+      components.gateway.type: ingress
+      components.gateway.ingress.className: alb
+      components.gateway.ingress.hosts:
+        - host: api.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+              externalService: backend-service
+              port: 8080
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: ingress-only component does not produce a Service
+    templates:
+      - templates/service.yaml
+    set:
+      components.gateway.type: ingress
+      components.gateway.ingress.className: alb
+      components.gateway.ingress.hosts:
+        - host: api.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+              externalService: backend
+              port: 8080
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: ingress-only component does not produce an HPA
+    templates:
+      - templates/hpa.yaml
+    set:
+      components.gateway.type: ingress
+      components.gateway.ingress.className: alb
+      components.gateway.ingress.hosts:
+        - host: api.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+              externalService: backend
+              port: 8080
+      components.gateway.hpa.minReplicas: 1
+      components.gateway.hpa.maxReplicas: 5
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: ingress-only component does not produce a ServiceAccount
+    templates:
+      - templates/serviceaccount.yaml
+    set:
+      components.gateway.type: ingress
+      components.gateway.serviceAccountCreate: true
+      components.gateway.serviceAccountName: gateway-sa
+      components.gateway.ingress.className: alb
+      components.gateway.ingress.hosts:
+        - host: api.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+              externalService: backend
+              port: 8080
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: ingress-only component does produce an Ingress resource
+    templates:
+      - templates/ingress.yaml
+    set:
+      components.gateway.type: ingress
+      components.gateway.ingress.className: alb
+      components.gateway.ingress.hosts:
+        - host: api.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+              externalService: backend-service
+              port: 8080
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.ingressClassName
+          value: alb
+      - equal:
+          path: spec.rules[0].host
+          value: api.example.com
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: backend-service
+
+  - it: ingress backend defaults to the component service when externalService is unset
+    templates:
+      - templates/ingress.yaml
+    values:
+      - ../testing-values/values-minimal.yaml
+    set:
+      components.api.ingress.className: nginx
+      components.api.ingress.hosts:
+        - host: api.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+              port: 3000
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: test-api
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 3000
+
+  - it: ingress accepts servicePort as alias for port for backward compatibility
+    templates:
+      - templates/ingress.yaml
+    values:
+      - ../testing-values/values-minimal.yaml
+    set:
+      components.api.ingress.className: nginx
+      components.api.ingress.hosts:
+        - host: api.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+              servicePort: 3000
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 3000
+
+  - it: ingress renders TLS configuration when provided
+    templates:
+      - templates/ingress.yaml
+    set:
+      components.gateway.type: ingress
+      components.gateway.ingress.className: alb
+      components.gateway.ingress.hosts:
+        - host: api.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+              externalService: backend
+              port: 80
+      components.gateway.ingress.tls:
+        - secretName: api-tls
+          hosts:
+            - api.example.com
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: api-tls
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: api.example.com

--- a/complex/tests/init_containers_test.yaml
+++ b/complex/tests/init_containers_test.yaml
@@ -1,0 +1,74 @@
+suite: initContainers propagation into Deployment pod spec
+release:
+  name: test
+templates:
+  - templates/deployment.yaml
+values:
+  - ../testing-values/values-minimal.yaml
+tests:
+  - it: omits initContainers when none are configured
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+
+  - it: renders a single init container with image, command and resources
+    set:
+      components.api.initContainers.wait-for-db.image.repository: busybox
+      components.api.initContainers.wait-for-db.image.tag: "1.36"
+      components.api.initContainers.wait-for-db.command:
+        - sh
+        - -c
+        - "until nc -z postgres 5432; do sleep 2; done"
+      components.api.initContainers.wait-for-db.resources.requests.cpu: 50m
+      components.api.initContainers.wait-for-db.resources.requests.memory: 64M
+      components.api.initContainers.wait-for-db.resources.requests.ephemeralStorage: 128Mi
+      components.api.initContainers.wait-for-db.resources.limits.cpu: 100m
+      components.api.initContainers.wait-for-db.resources.limits.memory: 128M
+      components.api.initContainers.wait-for-db.resources.limits.ephemeralStorage: 128Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-db
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: busybox:1.36
+      - equal:
+          path: spec.template.spec.initContainers[0].command[0]
+          value: sh
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.requests.cpu
+          value: 50m
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.limits.memory
+          value: 128M
+
+  - it: renders multiple init containers in order
+    set:
+      components.api.initContainers.first-step.image.repository: busybox
+      components.api.initContainers.first-step.image.tag: "1.36"
+      components.api.initContainers.first-step.command:
+        - echo
+        - "step 1"
+      components.api.initContainers.second-step.image.repository: busybox
+      components.api.initContainers.second-step.image.tag: "1.36"
+      components.api.initContainers.second-step.command:
+        - echo
+        - "step 2"
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 2
+
+  - it: init container does not leak into main containers list
+    set:
+      components.api.initContainers.wait-for-db.image.repository: busybox
+      components.api.initContainers.wait-for-db.image.tag: "1.36"
+      components.api.initContainers.wait-for-db.command:
+        - sh
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: application

--- a/complex/tests/keda_kafka_sqs_test.yaml
+++ b/complex/tests/keda_kafka_sqs_test.yaml
@@ -231,4 +231,4 @@ tests:
         - type: not-a-real-trigger
     asserts:
       - failedTemplate:
-          errorPattern: "Must validate at least one schema"
+          errorPattern: "(Must validate at least one schema|'anyOf' failed)"

--- a/complex/tests/keda_kafka_sqs_test.yaml
+++ b/complex/tests/keda_kafka_sqs_test.yaml
@@ -1,0 +1,234 @@
+suite: KEDA Kafka and AWS SQS scaler triggers
+release:
+  name: test
+templates:
+  - templates/keda-scaledobject.yaml
+set:
+  global.container.image.repository: cookielab/deployer
+  global.container.image.tag: 1.0.0-rc2
+  components.consumer-foo.type: consumer
+  components.consumer-foo.command:
+    - bin/consume
+  components.consumer-foo.keda.minReplicaCount: 1
+  components.consumer-foo.keda.maxReplicaCount: 10
+tests:
+  - it: renders Kafka trigger with explicit awsRegion
+    set:
+      components.consumer-foo.keda.triggers:
+        - type: kafka
+          bootstrapServers: kafka:9092
+          topic: orders
+          consumerGroup: order-consumers
+          lagThreshold: 10
+          awsRegion: us-east-1
+    asserts:
+      - equal:
+          path: spec.triggers[0].type
+          value: kafka
+      - equal:
+          path: spec.triggers[0].metadata.bootstrapServers
+          value: kafka:9092
+      - equal:
+          path: spec.triggers[0].metadata.topic
+          value: orders
+      - equal:
+          path: spec.triggers[0].metadata.consumerGroup
+          value: order-consumers
+      - equal:
+          path: spec.triggers[0].metadata.lagThreshold
+          value: "10"
+      - equal:
+          path: spec.triggers[0].metadata.awsRegion
+          value: us-east-1
+      - equal:
+          path: spec.triggers[0].metadata.sasl
+          value: oauthbearer
+      - equal:
+          path: spec.triggers[0].metadata.saslTokenProvider
+          value: aws_msk_iam
+
+  - it: Kafka trigger falls back to global awsRegion when not set on trigger
+    set:
+      global.keda.awsRegion: eu-west-1
+      components.consumer-foo.keda.triggers:
+        - type: kafka
+          bootstrapServers: kafka:9092
+          topic: events
+          consumerGroup: event-consumers
+          lagThreshold: 5
+    asserts:
+      - equal:
+          path: spec.triggers[0].metadata.awsRegion
+          value: eu-west-1
+
+  - it: Kafka trigger with identityOwner pod skips SASL/awsRegion fields
+    set:
+      global.keda.awsRegion: eu-west-1
+      components.consumer-foo.keda.triggers:
+        - type: kafka
+          bootstrapServers: kafka:9092
+          topic: events
+          consumerGroup: event-consumers
+          lagThreshold: 5
+          identityOwner: pod
+    asserts:
+      - equal:
+          path: spec.triggers[0].metadata.identityOwner
+          value: pod
+      - notExists:
+          path: spec.triggers[0].metadata.sasl
+      - notExists:
+          path: spec.triggers[0].metadata.saslTokenProvider
+      - notExists:
+          path: spec.triggers[0].metadata.awsRegion
+
+  - it: Kafka trigger defaults offsetResetPolicy to earliest
+    set:
+      components.consumer-foo.keda.triggers:
+        - type: kafka
+          bootstrapServers: kafka:9092
+          topic: events
+          consumerGroup: event-consumers
+          lagThreshold: 5
+          awsRegion: us-east-1
+    asserts:
+      - equal:
+          path: spec.triggers[0].metadata.offsetResetPolicy
+          value: earliest
+
+  - it: Kafka trigger fails without any awsRegion
+    set:
+      components.consumer-foo.keda.triggers:
+        - type: kafka
+          bootstrapServers: kafka:9092
+          topic: events
+          consumerGroup: event-consumers
+          lagThreshold: 5
+    asserts:
+      - failedTemplate:
+          errorMessage: "Kafka trigger for 'consumer-foo' is missing required field(s)."
+
+  - it: renders SQS trigger with operator identityOwner (default)
+    set:
+      components.consumer-foo.envs.values.SQS_QUEUE: https://sqs.eu-west-1.amazonaws.com/123/test
+      components.consumer-foo.keda.triggers:
+        - type: aws-sqs-queue
+          queueURLFromEnv: SQS_QUEUE
+          queueLength: 5
+          awsRegion: eu-west-1
+    asserts:
+      - equal:
+          path: spec.triggers[0].type
+          value: aws-sqs-queue
+      - equal:
+          path: spec.triggers[0].metadata.awsRegion
+          value: eu-west-1
+      - equal:
+          path: spec.triggers[0].metadata.queueLength
+          value: "5"
+      - equal:
+          path: spec.triggers[0].metadata.queueURLFromEnv
+          value: SQS_QUEUE
+      - equal:
+          path: spec.triggers[0].metadata.identityOwner
+          value: operator
+      - notExists:
+          path: spec.triggers[0].authenticationRef
+
+  - it: SQS trigger with identityOwner pod adds authenticationRef
+    set:
+      components.consumer-foo.envs.values.SQS_QUEUE: https://sqs.eu-west-1.amazonaws.com/123/test
+      components.consumer-foo.keda.triggers:
+        - type: aws-sqs-queue
+          queueURLFromEnv: SQS_QUEUE
+          queueLength: 5
+          awsRegion: eu-west-1
+          identityOwner: pod
+    asserts:
+      - equal:
+          path: spec.triggers[0].metadata.identityOwner
+          value: pod
+      - equal:
+          path: spec.triggers[0].authenticationRef.name
+          value: consumer-foo-auth-0
+
+  - it: SQS trigger falls back to global awsRegion
+    set:
+      global.keda.awsRegion: us-east-1
+      components.consumer-foo.envs.values.SQS_QUEUE: https://sqs.us-east-1.amazonaws.com/123/test
+      components.consumer-foo.keda.triggers:
+        - type: aws-sqs-queue
+          queueURLFromEnv: SQS_QUEUE
+          queueLength: 5
+    asserts:
+      - equal:
+          path: spec.triggers[0].metadata.awsRegion
+          value: us-east-1
+
+  - it: SQS trigger fails without any awsRegion
+    set:
+      components.consumer-foo.envs.values.SQS_QUEUE: https://sqs.eu-west-1.amazonaws.com/123/test
+      components.consumer-foo.keda.triggers:
+        - type: aws-sqs-queue
+          queueURLFromEnv: SQS_QUEUE
+          queueLength: 5
+    asserts:
+      - failedTemplate:
+          errorMessage: "SQS trigger for 'consumer-foo' is missing required field(s)."
+
+  - it: renders Cron trigger with desiredReplicas
+    set:
+      components.consumer-foo.keda.triggers:
+        - type: cron
+          timezone: Europe/Prague
+          start: "0 6 * * *"
+          end: "0 18 * * *"
+          desiredReplicas: 3
+    asserts:
+      - equal:
+          path: spec.triggers[0].type
+          value: cron
+      - equal:
+          path: spec.triggers[0].metadata.timezone
+          value: Europe/Prague
+      - equal:
+          path: spec.triggers[0].metadata.start
+          value: "0 6 * * *"
+      - equal:
+          path: spec.triggers[0].metadata.end
+          value: "0 18 * * *"
+      - equal:
+          path: spec.triggers[0].metadata.desiredReplicas
+          value: "3"
+
+  - it: renders multiple triggers in order
+    set:
+      global.keda.awsRegion: eu-west-1
+      components.consumer-foo.envs.values.SQS_QUEUE: https://sqs.eu-west-1.amazonaws.com/123/test
+      components.consumer-foo.keda.triggers:
+        - type: aws-sqs-queue
+          queueURLFromEnv: SQS_QUEUE
+          queueLength: 5
+        - type: cron
+          timezone: UTC
+          start: "0 0 * * *"
+          end: "0 12 * * *"
+          desiredReplicas: 2
+    asserts:
+      - lengthEqual:
+          path: spec.triggers
+          count: 2
+      - equal:
+          path: spec.triggers[0].type
+          value: aws-sqs-queue
+      - equal:
+          path: spec.triggers[1].type
+          value: cron
+
+  - it: fails on unknown trigger type
+    set:
+      components.consumer-foo.keda.triggers:
+        - type: not-a-real-trigger
+    asserts:
+      - failedTemplate:
+          errorPattern: "Must validate at least one schema"

--- a/complex/tests/keda_prometheus_trigger_test.yaml
+++ b/complex/tests/keda_prometheus_trigger_test.yaml
@@ -1,0 +1,148 @@
+suite: KEDA Prometheus scaler trigger
+release:
+  name: test
+templates:
+  - templates/keda-scaledobject.yaml
+set:
+  global.container.image.repository: cookielab/deployer
+  global.container.image.tag: 1.0.0-rc2
+  components.consumer-foo.type: consumer
+  components.consumer-foo.command:
+    - bin/consume
+  components.consumer-foo.keda.minReplicaCount: 1
+  components.consumer-foo.keda.maxReplicaCount: 10
+tests:
+  - it: renders prometheus trigger with metricName and required fields
+    set:
+      components.consumer-foo.keda.triggers:
+        - type: prometheus
+          serverAddress: http://prometheus:9090
+          metricName: http_requests_total
+          threshold: 100
+    asserts:
+      - isKind:
+          of: ScaledObject
+      - equal:
+          path: spec.triggers[0].type
+          value: prometheus
+      - equal:
+          path: spec.triggers[0].metadata.serverAddress
+          value: http://prometheus:9090
+      - equal:
+          path: spec.triggers[0].metadata.metricName
+          value: http_requests_total
+      - equal:
+          path: spec.triggers[0].metadata.threshold
+          value: 100
+      - notExists:
+          path: spec.triggers[0].metadata.query
+
+  - it: renders prometheus trigger with query instead of metricName
+    set:
+      components.consumer-foo.keda.triggers:
+        - type: prometheus
+          serverAddress: http://prometheus:9090
+          query: 'sum(rate(http_requests_total[5m]))'
+          threshold: 200
+    asserts:
+      - equal:
+          path: spec.triggers[0].metadata.query
+          value: sum(rate(http_requests_total[5m]))
+      - notExists:
+          path: spec.triggers[0].metadata.metricName
+
+  - it: preserves float thresholds without quoting them
+    set:
+      components.consumer-foo.keda.triggers:
+        - type: prometheus
+          serverAddress: http://prometheus:9090
+          metricName: rps
+          threshold: 100.5
+          activationThreshold: 50.25
+    asserts:
+      - equal:
+          path: spec.triggers[0].metadata.threshold
+          value: 100.5
+      - equal:
+          path: spec.triggers[0].metadata.activationThreshold
+          value: 50.25
+
+  - it: emits all optional fields when provided
+    set:
+      components.consumer-foo.keda.triggers:
+        - type: prometheus
+          serverAddress: https://prometheus.example.com:9090
+          metricName: rps
+          threshold: 100
+          ignoreNullValues: true
+          unsafeSsl: true
+          customHeaders: "X-Header:value"
+          namespace: monitoring
+          queryParameters: "timeout=30s"
+    asserts:
+      - equal:
+          path: spec.triggers[0].metadata.ignoreNullValues
+          value: "true"
+      - equal:
+          path: spec.triggers[0].metadata.unsafeSsl
+          value: "true"
+      - equal:
+          path: spec.triggers[0].metadata.customHeaders
+          value: "X-Header:value"
+      - equal:
+          path: spec.triggers[0].metadata.namespace
+          value: monitoring
+      - equal:
+          path: spec.triggers[0].metadata.queryParameters
+          value: timeout=30s
+
+  - it: omits optional fields when they are not set
+    set:
+      components.consumer-foo.keda.triggers:
+        - type: prometheus
+          serverAddress: http://prometheus:9090
+          metricName: rps
+          threshold: 100
+    asserts:
+      - notExists:
+          path: spec.triggers[0].metadata.activationThreshold
+      - notExists:
+          path: spec.triggers[0].metadata.ignoreNullValues
+      - notExists:
+          path: spec.triggers[0].metadata.unsafeSsl
+      - notExists:
+          path: spec.triggers[0].metadata.customHeaders
+      - notExists:
+          path: spec.triggers[0].metadata.namespace
+      - notExists:
+          path: spec.triggers[0].metadata.queryParameters
+
+  - it: schema rejects prometheus trigger missing serverAddress
+    set:
+      components.consumer-foo.keda.triggers:
+        - type: prometheus
+          metricName: rps
+          threshold: 100
+    asserts:
+      - failedTemplate:
+          errorPattern: "serverAddress is required"
+
+  - it: schema rejects prometheus trigger missing metricName and query
+    set:
+      components.consumer-foo.keda.triggers:
+        - type: prometheus
+          serverAddress: http://prometheus:9090
+          threshold: 100
+    asserts:
+      - failedTemplate:
+          errorPattern: "metricName is required"
+
+  - it: schema rejects prometheus trigger missing threshold
+    set:
+      components.consumer-foo.keda.triggers:
+        - type: prometheus
+          serverAddress: http://prometheus:9090
+          metricName: rps
+    asserts:
+      - failedTemplate:
+          errorPattern: "threshold is required"

--- a/complex/tests/keda_prometheus_trigger_test.yaml
+++ b/complex/tests/keda_prometheus_trigger_test.yaml
@@ -125,7 +125,7 @@ tests:
           threshold: 100
     asserts:
       - failedTemplate:
-          errorPattern: "serverAddress is required"
+          errorPattern: "(serverAddress is required|missing property 'serverAddress')"
 
   - it: schema rejects prometheus trigger missing metricName and query
     set:
@@ -135,7 +135,7 @@ tests:
           threshold: 100
     asserts:
       - failedTemplate:
-          errorPattern: "metricName is required"
+          errorPattern: "(metricName is required|missing property 'metricName')"
 
   - it: schema rejects prometheus trigger missing threshold
     set:
@@ -145,4 +145,4 @@ tests:
           metricName: rps
     asserts:
       - failedTemplate:
-          errorPattern: "threshold is required"
+          errorPattern: "(threshold is required|missing property 'threshold')"

--- a/complex/tests/keda_trigger_authentication_test.yaml
+++ b/complex/tests/keda_trigger_authentication_test.yaml
@@ -64,6 +64,18 @@ tests:
           path: spec.podIdentity.provider
           value: aws
 
+  - it: respects triggerAuthEnabled false override
+    set:
+      components.consumer-foo.keda.triggers:
+        - type: aws-sqs-queue
+          queueURLFromEnv: SQS_QUEUE
+          queueLength: 5
+          identityOwner: pod
+          triggerAuthEnabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: renders one TriggerAuthentication per SQS trigger with pod identity
     set:
       components.consumer-foo.envs.values.SQS_QUEUE_A: https://sqs.eu-west-1.amazonaws.com/123/a

--- a/complex/tests/keda_trigger_authentication_test.yaml
+++ b/complex/tests/keda_trigger_authentication_test.yaml
@@ -1,0 +1,103 @@
+suite: KEDA TriggerAuthentication for SQS pod identity
+release:
+  name: test
+templates:
+  - templates/keda-triggerauthentication.yaml
+set:
+  global.container.image.repository: cookielab/deployer
+  global.container.image.tag: 1.0.0-rc2
+  global.keda.awsRegion: eu-west-1
+  components.consumer-foo.type: consumer
+  components.consumer-foo.command:
+    - bin/consume
+  components.consumer-foo.envs.values.SQS_QUEUE: https://sqs.eu-west-1.amazonaws.com/123/test
+  components.consumer-foo.keda.minReplicaCount: 1
+  components.consumer-foo.keda.maxReplicaCount: 5
+tests:
+  - it: does not render TriggerAuthentication for consumers without keda
+    set:
+      components.plain-consumer.type: consumer
+      components.plain-consumer.command:
+        - bin/work
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render TriggerAuthentication for operator identityOwner (default)
+    set:
+      components.consumer-foo.keda.triggers:
+        - type: aws-sqs-queue
+          queueURLFromEnv: SQS_QUEUE
+          queueLength: 5
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render TriggerAuthentication when explicit operator identityOwner
+    set:
+      components.consumer-foo.keda.triggers:
+        - type: aws-sqs-queue
+          queueURLFromEnv: SQS_QUEUE
+          queueLength: 5
+          identityOwner: operator
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders TriggerAuthentication for SQS trigger with pod identityOwner
+    set:
+      components.consumer-foo.keda.triggers:
+        - type: aws-sqs-queue
+          queueURLFromEnv: SQS_QUEUE
+          queueLength: 5
+          identityOwner: pod
+    asserts:
+      - isKind:
+          of: TriggerAuthentication
+      - equal:
+          path: apiVersion
+          value: keda.sh/v1alpha1
+      - equal:
+          path: metadata.name
+          value: test-consumer-foo-auth-0
+      - equal:
+          path: spec.podIdentity.provider
+          value: aws
+
+  - it: renders one TriggerAuthentication per SQS trigger with pod identity
+    set:
+      components.consumer-foo.envs.values.SQS_QUEUE_A: https://sqs.eu-west-1.amazonaws.com/123/a
+      components.consumer-foo.envs.values.SQS_QUEUE_B: https://sqs.eu-west-1.amazonaws.com/123/b
+      components.consumer-foo.keda.triggers:
+        - type: aws-sqs-queue
+          queueURLFromEnv: SQS_QUEUE_A
+          queueLength: 5
+          identityOwner: pod
+        - type: aws-sqs-queue
+          queueURLFromEnv: SQS_QUEUE_B
+          queueLength: 5
+          identityOwner: pod
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: test-consumer-foo-auth-0
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: test-consumer-foo-auth-1
+        documentIndex: 1
+
+  - it: skips trigger types other than aws-sqs-queue
+    set:
+      components.consumer-foo.keda.triggers:
+        - type: kafka
+          bootstrapServers: kafka:9092
+          topic: t
+          consumerGroup: g
+          lagThreshold: 5
+          identityOwner: pod
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/complex/tests/node_name_test.yaml
+++ b/complex/tests/node_name_test.yaml
@@ -1,0 +1,63 @@
+suite: nodeName propagation across workload kinds
+release:
+  name: test
+values:
+  - ../testing-values/values-minimal.yaml
+tests:
+  - it: omits nodeName from Deployment pod spec when unset
+    templates:
+      - templates/deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.nodeName
+
+  - it: propagates nodeName to Deployment pod spec
+    templates:
+      - templates/deployment.yaml
+    set:
+      components.api.nodeName: ip-10-0-0-1.ec2.internal
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeName
+          value: ip-10-0-0-1.ec2.internal
+
+  - it: propagates nodeName to consumer Deployment pod spec
+    templates:
+      - templates/deployment.yaml
+    set:
+      components.worker.type: consumer
+      components.worker.command:
+        - bin/consume
+      components.worker.nodeName: ip-10-0-0-2.ec2.internal
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeName
+          value: ip-10-0-0-2.ec2.internal
+        documentIndex: 1
+
+  - it: propagates nodeName to CronJob pod spec
+    templates:
+      - templates/cronJob.yaml
+    set:
+      components.cron.type: cronjob
+      components.cron.schedule: "0 * * * *"
+      components.cron.command:
+        - bin/cron-task
+      components.cron.nodeName: ip-10-0-0-3.ec2.internal
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.nodeName
+          value: ip-10-0-0-3.ec2.internal
+
+  - it: propagates nodeName to pre-job pod spec
+    templates:
+      - templates/job.yaml
+    set:
+      components.migrate.type: pre-job
+      components.migrate.command:
+        - bin/migrate
+      components.migrate.nodeName: ip-10-0-0-4.ec2.internal
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeName
+          value: ip-10-0-0-4.ec2.internal

--- a/complex/tests/persistent_volume_claim_test.yaml
+++ b/complex/tests/persistent_volume_claim_test.yaml
@@ -1,0 +1,98 @@
+suite: persistentVolumeClaim creation and existing claim reuse
+release:
+  name: test
+values:
+  - ../testing-values/values-minimal.yaml
+tests:
+  - it: does not create a PVC when persistentVolumeClaim is unset
+    templates:
+      - templates/persistentvolumeclaim.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: creates a PVC with sensible defaults when only size is set
+    templates:
+      - templates/persistentvolumeclaim.yaml
+    set:
+      components.api.persistentVolumeClaim.size: 5Gi
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: test-api
+      - equal:
+          path: spec.resources.requests.storage
+          value: 5Gi
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteOnce
+      - notExists:
+          path: spec.storageClassName
+
+  - it: honours storageClassName, accessModes, annotations and labels
+    templates:
+      - templates/persistentvolumeclaim.yaml
+    set:
+      components.api.persistentVolumeClaim.size: 10Gi
+      components.api.persistentVolumeClaim.storageClassName: efs-sc
+      components.api.persistentVolumeClaim.accessModes:
+        - ReadWriteMany
+      components.api.persistentVolumeClaim.annotations:
+        efs.csi.aws.com/access-point-id: fsap-test
+      components.api.persistentVolumeClaim.labels:
+        storage-tier: premium
+    asserts:
+      - equal:
+          path: spec.storageClassName
+          value: efs-sc
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteMany
+      - equal:
+          path: metadata.annotations["efs.csi.aws.com/access-point-id"]
+          value: fsap-test
+      - equal:
+          path: metadata.labels["storage-tier"]
+          value: premium
+
+  - it: skips PVC creation when useExistingClaim is true
+    templates:
+      - templates/persistentvolumeclaim.yaml
+    set:
+      components.api.persistentVolumeClaim.useExistingClaim: true
+      components.api.persistentVolumeClaim.existingClaimName: shared-efs-pvc
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: pod spec references generated PVC by component name
+    templates:
+      - templates/deployment.yaml
+    set:
+      components.api.persistentVolumeClaim.size: 5Gi
+      components.api.volumeMounts.others:
+        - name: data
+          mountPath: /data
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: data
+      - equal:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: test-api
+
+  - it: pod spec references existing claim name when useExistingClaim is true
+    templates:
+      - templates/deployment.yaml
+    set:
+      components.api.persistentVolumeClaim.useExistingClaim: true
+      components.api.persistentVolumeClaim.existingClaimName: shared-efs-pvc
+      components.api.volumeMounts.others:
+        - name: data
+          mountPath: /data
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: shared-efs-pvc

--- a/complex/tests/pod_disruption_budget_test.yaml
+++ b/complex/tests/pod_disruption_budget_test.yaml
@@ -1,0 +1,70 @@
+suite: PodDisruptionBudget integer and percentage values
+release:
+  name: test
+templates:
+  - templates/podDisruptionBudget.yaml
+values:
+  - ../testing-values/values-minimal.yaml
+tests:
+  - it: does not create a PDB when component has no pdb config
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders integer minAvailable as a number, not a quoted string
+    set:
+      components.api.pdb.minAvailable: 1
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - notExists:
+          path: spec.maxUnavailable
+
+  - it: renders integer maxUnavailable as a number
+    set:
+      components.api.pdb.maxUnavailable: 2
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 2
+      - notExists:
+          path: spec.minAvailable
+
+  - it: preserves percentage minAvailable as a string
+    set:
+      components.api.pdb.minAvailable: 50%
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 50%
+
+  - it: preserves percentage maxUnavailable as a string
+    set:
+      components.api.pdb.maxUnavailable: 33%
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 33%
+
+  - it: appends extraMatchLabels into the selector alongside default labels
+    set:
+      components.api.pdb.minAvailable: 1
+      components.api.pdb.extraMatchLabels:
+        custom.label: custom-value
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["custom.label"]
+          value: custom-value
+      - exists:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+
+  - it: names the PDB after the component with a -pdb suffix
+    set:
+      components.api.pdb.minAvailable: 1
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-api-pdb

--- a/complex/tests/prometheus_rule_test.yaml
+++ b/complex/tests/prometheus_rule_test.yaml
@@ -1,0 +1,161 @@
+suite: PrometheusRule rendering for component alert rules and templates
+release:
+  name: test
+  namespace: monitoring
+templates:
+  - templates/prometheusRule.yaml
+values:
+  - ../testing-values/values-minimal.yaml
+tests:
+  - it: does not render PrometheusRule when no alertRules or alertTemplates are set
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders PrometheusRule with one alertRule
+    set:
+      components.api.alertRules:
+        HighErrorRate:
+          expression: rate(http_errors_total[5m]) > 0.1
+          for: 5m
+    asserts:
+      - isKind:
+          of: PrometheusRule
+      - equal:
+          path: apiVersion
+          value: monitoring.coreos.com/v1
+      - equal:
+          path: metadata.name
+          value: test
+      - equal:
+          path: spec.groups[0].name
+          value: test
+      - equal:
+          path: spec.groups[0].rules[0].alert
+          value: HighErrorRate
+      - equal:
+          path: spec.groups[0].rules[0].expr
+          value: rate(http_errors_total[5m]) > 0.1
+      - equal:
+          path: spec.groups[0].rules[0].for
+          value: 5m
+
+  - it: defaults alertRule for to 1m when not set
+    set:
+      components.api.alertRules:
+        Foo:
+          expression: up == 0
+    asserts:
+      - equal:
+          path: spec.groups[0].rules[0].for
+          value: 1m
+
+  - it: emits standard alert labels including severity default critical
+    set:
+      components.api.alertRules:
+        Foo:
+          expression: up == 0
+    asserts:
+      - equal:
+          path: spec.groups[0].rules[0].labels.severity
+          value: critical
+      - equal:
+          path: spec.groups[0].rules[0].labels.k8s_app_name
+          value: test
+      - equal:
+          path: spec.groups[0].rules[0].labels.k8s_app_component
+          value: api
+      - equal:
+          path: spec.groups[0].rules[0].labels.k8s_namespace_name
+          value: monitoring
+
+  - it: honours custom severity on alertRule
+    set:
+      components.api.alertRules:
+        Foo:
+          expression: up == 0
+          severity: warning
+    asserts:
+      - equal:
+          path: spec.groups[0].rules[0].labels.severity
+          value: warning
+
+  - it: merges global alertLabels into each rule
+    set:
+      global.alertLabels:
+        environment: production
+        team: platform
+      components.api.alertRules:
+        Foo:
+          expression: up == 0
+    asserts:
+      - equal:
+          path: spec.groups[0].rules[0].labels.environment
+          value: production
+      - equal:
+          path: spec.groups[0].rules[0].labels.team
+          value: platform
+
+  - it: renders alertTemplates with environment and project substitution
+    set:
+      global.alertLabels:
+        environment: staging
+      global.metadata.partOf: my-project
+      components.api.alertTemplates:
+        ServiceDown:
+          expression: |
+            up{environment="{{ .Environment }}", project="{{ .Project }}"} == 0
+          for: 2m
+          summary: Service is down
+          description: Service has been down for 2m
+    asserts:
+      - equal:
+          path: spec.groups[0].rules[0].alert
+          value: ServiceDown-staging
+      - matchRegex:
+          path: spec.groups[0].rules[0].expr
+          pattern: 'environment="staging"'
+      - matchRegex:
+          path: spec.groups[0].rules[0].expr
+          pattern: 'project="my-project"'
+      - equal:
+          path: spec.groups[0].rules[0].for
+          value: 2m
+      - equal:
+          path: spec.groups[0].rules[0].summary
+          value: Service is down
+
+  - it: alertTemplates fall back to default-env and default-project labels
+    set:
+      components.api.alertTemplates:
+        Foo:
+          expression: 'up{env="{{ .Environment }}", proj="{{ .Project }}"} == 0'
+          for: 1m
+          summary: s
+          description: d
+    asserts:
+      - equal:
+          path: spec.groups[0].rules[0].alert
+          value: Foo-default-env
+      - matchRegex:
+          path: spec.groups[0].rules[0].expr
+          pattern: 'env="default-env"'
+      - matchRegex:
+          path: spec.groups[0].rules[0].expr
+          pattern: 'proj="default-project"'
+
+  - it: renders both alertRules and alertTemplates within the same group
+    set:
+      components.api.alertRules:
+        DirectRule:
+          expression: up == 0
+      components.api.alertTemplates:
+        TemplatedRule:
+          expression: 'up{env="{{ .Environment }}"} == 0'
+          for: 1m
+          summary: s
+          description: d
+    asserts:
+      - lengthEqual:
+          path: spec.groups[0].rules
+          count: 2

--- a/complex/tests/recreate_strategy_test.yaml
+++ b/complex/tests/recreate_strategy_test.yaml
@@ -1,0 +1,55 @@
+suite: deployment strategy
+templates:
+  - templates/deployment.yaml
+release:
+  name: test
+values:
+  - ../testing-values/values-minimal.yaml
+tests:
+  - it: defaults to RollingUpdate when strategyType is unset
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - exists:
+          path: spec.strategy.rollingUpdate
+      - exists:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+      - exists:
+          path: spec.strategy.rollingUpdate.maxSurge
+
+  - it: explicit RollingUpdate behaves the same as default
+    set:
+      components.api.strategyType: RollingUpdate
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - exists:
+          path: spec.strategy.rollingUpdate
+
+  - it: switches to Recreate strategy when requested
+    set:
+      components.api.strategyType: Recreate
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - notExists:
+          path: spec.strategy.rollingUpdate
+
+  - it: Recreate strategy is independent per component
+    set:
+      components.api.strategyType: Recreate
+      components.worker.type: consumer
+      components.worker.command:
+        - bin/consume
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+        documentIndex: 0
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+        documentIndex: 1

--- a/complex/tests/service_account_test.yaml
+++ b/complex/tests/service_account_test.yaml
@@ -118,3 +118,58 @@ tests:
           path: metadata.name
           value: shared-sa
         documentIndex: 1
+
+  - it: renders two SAs as separate documents when two components both create one
+    set:
+      components.api.serviceAccountCreate: true
+      components.api.serviceAccountName: api-sa
+      components.worker.type: consumer
+      components.worker.command:
+        - bin/consume
+      components.worker.serviceAccountCreate: true
+      components.worker.serviceAccountName: worker-sa
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: api-sa
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: worker-sa
+        documentIndex: 1
+      - isKind:
+          of: ServiceAccount
+        documentIndex: 0
+      - isKind:
+          of: ServiceAccount
+        documentIndex: 1
+
+  - it: renders three documents when two components and global all create SAs
+    set:
+      global.serviceAccountCreate: true
+      global.serviceAccountName: shared-sa
+      components.api.serviceAccountCreate: true
+      components.api.serviceAccountName: api-sa
+      components.worker.type: consumer
+      components.worker.command:
+        - bin/consume
+      components.worker.serviceAccountCreate: true
+      components.worker.serviceAccountName: worker-sa
+    asserts:
+      - hasDocuments:
+          count: 3
+      - isKind:
+          of: ServiceAccount
+        documentIndex: 0
+      - isKind:
+          of: ServiceAccount
+        documentIndex: 1
+      - isKind:
+          of: ServiceAccount
+        documentIndex: 2
+      - equal:
+          path: metadata.name
+          value: shared-sa
+        documentIndex: 2

--- a/complex/tests/service_account_test.yaml
+++ b/complex/tests/service_account_test.yaml
@@ -1,0 +1,120 @@
+suite: ServiceAccount creation per component and globally
+release:
+  name: test
+templates:
+  - templates/serviceaccount.yaml
+values:
+  - ../testing-values/values-minimal.yaml
+tests:
+  - it: does not create a ServiceAccount when no flags are set
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not create a SA when only serviceAccountName is set without create flag
+    set:
+      components.api.serviceAccountName: existing-sa
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: creates a component-level ServiceAccount when serviceAccountCreate is true
+    set:
+      components.api.serviceAccountCreate: true
+      components.api.serviceAccountName: api-sa
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: apiVersion
+          value: v1
+      - equal:
+          path: metadata.name
+          value: api-sa
+
+  - it: marks the SA as a pre-install/pre-upgrade hook with keep policy
+    set:
+      components.api.serviceAccountCreate: true
+      components.api.serviceAccountName: api-sa
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-10"
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: skips component-level SA creation for cronjob components
+    set:
+      components.cron.type: cronjob
+      components.cron.schedule: "0 * * * *"
+      components.cron.command:
+        - bin/task
+      components.cron.serviceAccountCreate: true
+      components.cron.serviceAccountName: cron-sa
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: skips component-level SA creation for pre-job components
+    set:
+      components.migrate.type: pre-job
+      components.migrate.command:
+        - bin/migrate
+      components.migrate.serviceAccountCreate: true
+      components.migrate.serviceAccountName: migrate-sa
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: skips component-level SA creation for ingress components
+    set:
+      components.gateway.type: ingress
+      components.gateway.serviceAccountCreate: true
+      components.gateway.serviceAccountName: gateway-sa
+      components.gateway.ingress.className: alb
+      components.gateway.ingress.hosts:
+        - host: api.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+              externalService: backend
+              port: 80
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: creates a global ServiceAccount when global.serviceAccountCreate is true
+    set:
+      global.serviceAccountCreate: true
+      global.serviceAccountName: shared-sa
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: shared-sa
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: creates both component and global SAs when both are configured
+    set:
+      global.serviceAccountCreate: true
+      global.serviceAccountName: shared-sa
+      components.api.serviceAccountCreate: true
+      components.api.serviceAccountName: api-sa
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: api-sa
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: shared-sa
+        documentIndex: 1

--- a/complex/tests/service_test.yaml
+++ b/complex/tests/service_test.yaml
@@ -1,0 +1,161 @@
+suite: Service rendering
+templates:
+  - templates/service.yaml
+release:
+  name: test
+values:
+  - ../testing-values/values-minimal.yaml
+tests:
+  - it: renders a Service for a http component
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: test-api
+
+  - it: renders a Service for a http-internal component
+    set:
+      components.api.type: http-internal
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+
+  - it: does not render a Service for a consumer component
+    set:
+      components.worker.type: consumer
+      components.worker.command:
+        - bin/consume
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: test-api
+
+  - it: does not render a Service for a cronjob component
+    set:
+      components.cron.type: cronjob
+      components.cron.schedule: "*/5 * * * *"
+      components.cron.command:
+        - bin/cron-task
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: test-api
+
+  - it: does not render a Service for a pre-job component
+    set:
+      components.migrate.type: pre-job
+      components.migrate.command:
+        - bin/migrate
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: test-api
+
+  - it: defaults service type to ClusterIP
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: allows component-level override of service type to LoadBalancer
+    set:
+      components.api.service.type: LoadBalancer
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+
+  - it: inherits service type from global.service.type
+    set:
+      global.service.type: LoadBalancer
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+
+  - it: component service type wins over global service type
+    set:
+      global.service.type: LoadBalancer
+      components.api.service.type: ClusterIP
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: renders a single port with TCP protocol and matching targetPort
+    asserts:
+      - lengthEqual:
+          path: spec.ports
+          count: 1
+      - equal:
+          path: spec.ports[0].port
+          value: 3000
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 3000
+      - equal:
+          path: spec.ports[0].protocol
+          value: TCP
+
+  - it: renders multiple ports
+    set:
+      components.api.ports:
+        - name: http
+          port: 8080
+        - name: metrics
+          port: 9090
+    asserts:
+      - lengthEqual:
+          path: spec.ports
+          count: 2
+      - equal:
+          path: spec.ports[0].name
+          value: http
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+      - equal:
+          path: spec.ports[1].name
+          value: metrics
+      - equal:
+          path: spec.ports[1].port
+          value: 9090
+
+  - it: emits selector with component label so Service binds matching Pods
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: api
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: test
+
+  - it: renders one Service per http/http-internal component
+    set:
+      components.web.type: http-internal
+      components.web.replicas: 1
+      components.web.ports:
+        - port: 4000
+      components.web.probes:
+        readinessProbe:
+          httpGet:
+            port: 4000
+            path: /
+        livenessProbe:
+          httpGet:
+            port: 4000
+            path: /
+    asserts:
+      - hasDocuments:
+          count: 2

--- a/complex/tests/target_group_binding_test.yaml
+++ b/complex/tests/target_group_binding_test.yaml
@@ -1,0 +1,144 @@
+suite: TargetGroupBinding (AWS Load Balancer Controller integration)
+release:
+  name: test
+templates:
+  - templates/targetGroupBinding.yaml
+tests:
+  - it: renders a single TargetGroupBinding from values-minimal targetGroup
+    values:
+      - ../testing-values/values-minimal.yaml
+    asserts:
+      - isKind:
+          of: TargetGroupBinding
+      - equal:
+          path: apiVersion
+          value: elbv2.k8s.aws/v1beta1
+      - equal:
+          path: metadata.name
+          value: test-api
+      - equal:
+          path: spec.targetType
+          value: ip
+      - equal:
+          path: spec.targetGroupARN
+          value: arn:fake
+      - equal:
+          path: spec.serviceRef.name
+          value: test-api
+      - equal:
+          path: spec.serviceRef.port
+          value: 3000
+
+  - it: renders networking ingress block when securityGroupIds are set
+    values:
+      - ../testing-values/values-minimal.yaml
+    asserts:
+      - equal:
+          path: spec.networking.ingress[0].from[0].securityGroup.groupID
+          value: sg-fake
+
+  - it: renders one TargetGroupBinding per targetGroups entry with distinguisher suffix
+    set:
+      global.container.image.repository: cookielab/deployer
+      global.container.image.tag: 1.0.0-rc2
+      components.api.type: http
+      components.api.replicas: 1
+      components.api.ports[0].port: 3000
+      components.api.probes.readinessProbe.httpGet.port: 8080
+      components.api.probes.readinessProbe.httpGet.path: /h
+      components.api.probes.livenessProbe.httpGet.port: 8080
+      components.api.probes.livenessProbe.httpGet.path: /h
+      components.api.targetGroups:
+        - distinguisher: private
+          arn: arn:private
+          securityGroupIds:
+            - sg-private
+        - distinguisher: public
+          arn: arn:public
+          securityGroupIds:
+            - sg-public
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: test-api-private
+        documentIndex: 0
+      - equal:
+          path: spec.targetGroupARN
+          value: arn:private
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: test-api-public
+        documentIndex: 1
+      - equal:
+          path: spec.targetGroupARN
+          value: arn:public
+        documentIndex: 1
+
+  - it: omits suffix when targetGroup name is exactly "default"
+    set:
+      global.container.image.repository: cookielab/deployer
+      global.container.image.tag: 1.0.0-rc2
+      components.api.type: http
+      components.api.replicas: 1
+      components.api.ports[0].port: 3000
+      components.api.probes.readinessProbe.httpGet.port: 8080
+      components.api.probes.readinessProbe.httpGet.path: /h
+      components.api.probes.livenessProbe.httpGet.port: 8080
+      components.api.probes.livenessProbe.httpGet.path: /h
+      components.api.targetGroup.name: default
+      components.api.targetGroup.arn: arn:default
+      components.api.targetGroup.securityGroupIds:
+        - sg-fake
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-api
+
+  - it: appends -<name> suffix when targetGroup has a non-default name
+    set:
+      global.container.image.repository: cookielab/deployer
+      global.container.image.tag: 1.0.0-rc2
+      components.api.type: http
+      components.api.replicas: 1
+      components.api.ports[0].port: 3000
+      components.api.probes.readinessProbe.httpGet.port: 8080
+      components.api.probes.readinessProbe.httpGet.path: /h
+      components.api.probes.livenessProbe.httpGet.port: 8080
+      components.api.probes.livenessProbe.httpGet.path: /h
+      components.api.targetGroup.name: blue
+      components.api.targetGroup.arn: arn:blue
+      components.api.targetGroup.securityGroupIds:
+        - sg-fake
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-api-blue
+
+  - it: does not render binding when component has ingress configured
+    values:
+      - ../testing-values/values-minimal.yaml
+    set:
+      components.api.ingress.className: alb
+      components.api.ingress.hosts:
+        - host: api.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+              servicePort: 3000
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render binding for consumer components
+    set:
+      global.container.image.repository: cookielab/deployer
+      global.container.image.tag: 1.0.0-rc2
+      components.worker.type: consumer
+      components.worker.command:
+        - bin/consume
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/complex/tests/traefik_middleware_test.yaml
+++ b/complex/tests/traefik_middleware_test.yaml
@@ -1,0 +1,175 @@
+suite: Traefik Middleware resources and ingress reference resolution
+release:
+  name: test
+  namespace: default
+values:
+  - ../testing-values/values-minimal.yaml
+tests:
+  - it: does not render any Middleware resources by default
+    templates:
+      - templates/traefikMiddleware.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders global Middleware with release-prefixed name
+    templates:
+      - templates/traefikMiddleware.yaml
+    set:
+      global.traefikMiddlewares:
+        - name: security-headers
+          spec:
+            headers:
+              customResponseHeaders:
+                X-Frame-Options: DENY
+    asserts:
+      - isKind:
+          of: Middleware
+      - equal:
+          path: apiVersion
+          value: traefik.io/v1alpha1
+      - equal:
+          path: metadata.name
+          value: test-security-headers
+      - equal:
+          path: spec.headers.customResponseHeaders["X-Frame-Options"]
+          value: DENY
+
+  - it: renders component Middleware with component-prefixed name
+    templates:
+      - templates/traefikMiddleware.yaml
+    set:
+      components.api.traefikMiddlewares:
+        - name: strip-prefix
+          spec:
+            stripPrefix:
+              prefixes:
+                - /v1
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-api-strip-prefix
+      - equal:
+          path: spec.stripPrefix.prefixes[0]
+          value: /v1
+
+  - it: ingress translates component middleware ref to namespaced kubernetescrd address
+    templates:
+      - templates/ingress.yaml
+    set:
+      components.api.ingress.className: traefik
+      components.api.ingress.hosts:
+        - host: api.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+              servicePort: 3000
+      components.api.ingress.traefikMiddlewareRefs:
+        - strip-prefix
+      components.api.traefikMiddlewares:
+        - name: strip-prefix
+          spec:
+            stripPrefix:
+              prefixes:
+                - /v1
+    asserts:
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.middlewares"]
+          value: default-test-api-strip-prefix@kubernetescrd
+
+  - it: "ingress translates global: ref to release-prefixed kubernetescrd address"
+    templates:
+      - templates/ingress.yaml
+    set:
+      global.traefikMiddlewares:
+        - name: security-headers
+          spec:
+            headers:
+              customResponseHeaders:
+                X-Frame-Options: DENY
+      components.api.ingress.className: traefik
+      components.api.ingress.hosts:
+        - host: api.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+              servicePort: 3000
+      components.api.ingress.traefikMiddlewareRefs:
+        - global:security-headers
+    asserts:
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.middlewares"]
+          value: default-test-security-headers@kubernetescrd
+
+  - it: ingress passes external @-references through unchanged
+    templates:
+      - templates/ingress.yaml
+    set:
+      components.api.ingress.className: traefik
+      components.api.ingress.hosts:
+        - host: api.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+              servicePort: 3000
+      components.api.ingress.traefikMiddlewareRefs:
+        - auth@file
+    asserts:
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.middlewares"]
+          value: auth@file
+
+  - it: ingress joins multiple middleware refs with comma
+    templates:
+      - templates/ingress.yaml
+    set:
+      global.traefikMiddlewares:
+        - name: security-headers
+          spec:
+            headers:
+              customResponseHeaders:
+                X-Frame-Options: DENY
+      components.api.ingress.className: traefik
+      components.api.ingress.hosts:
+        - host: api.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+              servicePort: 3000
+      components.api.ingress.traefikMiddlewareRefs:
+        - global:security-headers
+        - rate-limit
+        - auth@file
+      components.api.traefikMiddlewares:
+        - name: rate-limit
+          spec:
+            rateLimit:
+              average: 100
+    asserts:
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.middlewares"]
+          value: default-test-security-headers@kubernetescrd,default-test-api-rate-limit@kubernetescrd,auth@file
+
+  - it: rejects manual middlewares annotation when traefikMiddlewareRefs is also used
+    templates:
+      - templates/ingress.yaml
+    set:
+      components.api.ingress.className: traefik
+      components.api.ingress.annotations:
+        traefik.ingress.kubernetes.io/router.middlewares: manual-value
+      components.api.ingress.hosts:
+        - host: api.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+              servicePort: 3000
+      components.api.ingress.traefikMiddlewareRefs:
+        - rate-limit
+      components.api.traefikMiddlewares:
+        - name: rate-limit
+          spec:
+            rateLimit:
+              average: 100
+    asserts:
+      - failedTemplate:
+          errorMessage: "Component 'api' cannot use both 'traefikMiddlewareRefs' and manual 'traefik.ingress.kubernetes.io/router.middlewares' annotation. Use only one."

--- a/complex/tests/volume_mount_readonly_test.yaml
+++ b/complex/tests/volume_mount_readonly_test.yaml
@@ -1,0 +1,142 @@
+suite: volumeMount readOnly behaviour
+templates:
+  - templates/deployment.yaml
+release:
+  name: test
+values:
+  - ../testing-values/values-minimal.yaml
+tests:
+  - it: defaults configMap volume mount to readOnly true when unset
+    set:
+      components.api.volumeMounts.configMaps:
+        - name: cm
+          configMapName: cm
+          mountPath: /etc/cm
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].name
+          value: cm
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].readOnly
+          value: true
+
+  - it: honours readOnly true on a configMap volume mount
+    set:
+      components.api.volumeMounts.configMaps:
+        - name: cm
+          configMapName: cm
+          mountPath: /etc/cm
+          readOnly: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].readOnly
+          value: true
+
+  - it: honours readOnly false on a configMap volume mount (regression for default-true bug)
+    set:
+      components.api.volumeMounts.configMaps:
+        - name: cm
+          configMapName: cm
+          mountPath: /etc/cm
+          readOnly: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].readOnly
+          value: false
+
+  - it: defaults secret volume mount to readOnly true when unset
+    set:
+      components.api.volumeMounts.secrets:
+        - name: sec
+          secretName: sec
+          mountPath: /etc/sec
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].name
+          value: sec
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].readOnly
+          value: true
+
+  - it: honours readOnly true on a secret volume mount
+    set:
+      components.api.volumeMounts.secrets:
+        - name: sec
+          secretName: sec
+          mountPath: /etc/sec
+          readOnly: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].readOnly
+          value: true
+
+  - it: honours readOnly false on a secret volume mount (regression for default-true bug)
+    set:
+      components.api.volumeMounts.secrets:
+        - name: sec
+          secretName: sec
+          mountPath: /etc/sec
+          readOnly: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].readOnly
+          value: false
+
+  - it: emptyDir volume mount preserves readOnly false
+    set:
+      components.api.volumeMounts.emptyDirs:
+        - name: scratch
+          mountPath: /scratch
+          sizeLimit: 100Mi
+          readOnly: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].name
+          value: scratch
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].readOnly
+          value: false
+
+  - it: emptyDir volume mount preserves readOnly true
+    set:
+      components.api.volumeMounts.emptyDirs:
+        - name: scratch
+          mountPath: /scratch
+          sizeLimit: 100Mi
+          readOnly: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].readOnly
+          value: true
+
+  - it: others volume mount preserves readOnly false
+    set:
+      components.api.persistentVolumeClaim:
+        size: 1Gi
+      components.api.volumeMounts.others:
+        - name: data
+          mountPath: /data
+          readOnly: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /data
+            readOnly: false
+
+  - it: others volume mount preserves readOnly true
+    set:
+      components.api.persistentVolumeClaim:
+        size: 1Gi
+      components.api.volumeMounts.others:
+        - name: data
+          mountPath: /data
+          readOnly: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /data
+            readOnly: true

--- a/complex/tests/vpa_test.yaml
+++ b/complex/tests/vpa_test.yaml
@@ -1,0 +1,118 @@
+suite: VerticalPodAutoscaler rendering
+release:
+  name: test
+templates:
+  - templates/vpa.yaml
+values:
+  - ../testing-values/values-minimal.yaml
+tests:
+  - it: does not render a VPA when vpa is unset
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render a VPA when vpa.enabled is false
+    set:
+      components.api.vpa.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a VPA targeting the component Deployment with defaults
+    set:
+      components.api.vpa.enabled: true
+    asserts:
+      - isKind:
+          of: VerticalPodAutoscaler
+      - equal:
+          path: apiVersion
+          value: autoscaling.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: test-api
+      - equal:
+          path: spec.targetRef.kind
+          value: Deployment
+      - equal:
+          path: spec.targetRef.name
+          value: test-api
+      - equal:
+          path: spec.updatePolicy.updateMode
+          value: Auto
+      - equal:
+          path: spec.resourcePolicy.containerPolicies[0].minAllowed.cpu
+          value: 50m
+      - equal:
+          path: spec.resourcePolicy.containerPolicies[0].minAllowed.memory
+          value: 128Mi
+      - equal:
+          path: spec.resourcePolicy.containerPolicies[0].maxAllowed.cpu
+          value: 500m
+      - equal:
+          path: spec.resourcePolicy.containerPolicies[0].maxAllowed.memory
+          value: 1Gi
+
+  - it: honours custom updateMode
+    set:
+      components.api.vpa.enabled: true
+      components.api.vpa.updateMode: "Off"
+    asserts:
+      - equal:
+          path: spec.updatePolicy.updateMode
+          value: "Off"
+
+  - it: honours custom min/max CPU and memory
+    set:
+      components.api.vpa.enabled: true
+      components.api.vpa.minCpu: 100m
+      components.api.vpa.maxCpu: "2"
+      components.api.vpa.minMemory: 256Mi
+      components.api.vpa.maxMemory: 4Gi
+    asserts:
+      - equal:
+          path: spec.resourcePolicy.containerPolicies[0].minAllowed.cpu
+          value: 100m
+      - equal:
+          path: spec.resourcePolicy.containerPolicies[0].maxAllowed.cpu
+          value: "2"
+      - equal:
+          path: spec.resourcePolicy.containerPolicies[0].minAllowed.memory
+          value: 256Mi
+      - equal:
+          path: spec.resourcePolicy.containerPolicies[0].maxAllowed.memory
+          value: 4Gi
+
+  - it: applies to all containers via wildcard containerName
+    set:
+      components.api.vpa.enabled: true
+    asserts:
+      - equal:
+          path: spec.resourcePolicy.containerPolicies[0].containerName
+          value: "*"
+      - equal:
+          path: spec.resourcePolicy.containerPolicies[0].controlledResources[0]
+          value: cpu
+      - equal:
+          path: spec.resourcePolicy.containerPolicies[0].controlledResources[1]
+          value: memory
+
+  - it: does not render VPA for cronjob components
+    set:
+      components.cron.type: cronjob
+      components.cron.schedule: "0 * * * *"
+      components.cron.command:
+        - bin/task
+      components.cron.vpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render VPA for pre-job components
+    set:
+      components.migrate.type: pre-job
+      components.migrate.command:
+        - bin/migrate
+      components.migrate.vpa.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/complex/values.schema.json
+++ b/complex/values.schema.json
@@ -676,6 +676,15 @@
         "OnFailure"
       ]
     },
+    "strategyType": {
+      "description": "Deployment strategy type. 'RollingUpdate' gradually replaces pods, 'Recreate' kills all existing pods before creating new ones.",
+      "type": "string",
+      "enum": [
+        "RollingUpdate",
+        "Recreate"
+      ],
+      "default": "RollingUpdate"
+    },
     "rollingUpdate": {
       "description": "Spec to control the desired behavior of rolling update.",
       "properties": {
@@ -2699,13 +2708,7 @@
           "$ref": "#/definitions/rollingUpdate"
         },
         "strategyType": {
-          "description": "Deployment strategy type. 'RollingUpdate' gradually replaces pods, 'Recreate' kills all existing pods before creating new ones.",
-          "type": "string",
-          "enum": [
-            "RollingUpdate",
-            "Recreate"
-          ],
-          "default": "RollingUpdate"
+          "$ref": "#/definitions/strategyType"
         },
         "nodeSelector": {
           "$ref": "#/definitions/nodeSelector"
@@ -3115,13 +3118,7 @@
             "$ref": "#/definitions/rollingUpdate"
           },
           "strategyType": {
-            "description": "Deployment strategy type. 'RollingUpdate' gradually replaces pods, 'Recreate' kills all existing pods before creating new ones.",
-            "type": "string",
-            "enum": [
-              "RollingUpdate",
-              "Recreate"
-            ],
-            "default": "RollingUpdate"
+            "$ref": "#/definitions/strategyType"
           },
           "envs": {
             "type": "object",

--- a/complex/values.schema.json
+++ b/complex/values.schema.json
@@ -35,6 +35,11 @@
         },
         "awsRegion": {
           "type": "string"
+        },
+        "triggerAuthEnabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "When identityOwner is 'pod', controls whether the chart auto-generates a TriggerAuthentication resource. Set to false to manage it externally. Has no effect when identityOwner is 'operator'."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
… features

Add unit tests for the three most recent features that were merged without dedicated tests: Recreate deployment strategy, nodeName propagation, and hostNetwork/dnsPolicy. Tests live in complex/tests/ and run via the helm-unittest plugin.

Also add three new files in complex/testing-values/ that exercise the same features end-to-end through helm template, and wire all of them into both the lint and template-test CI jobs. A new unit-test job runs the helm-unittest suites against the chart on every PR.