### PR TITLE
feat(complex): add external secrets support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,6 +85,7 @@ jobs:
           helm lint complex -f complex/testing-values/values-recreate.yaml
           helm lint complex -f complex/testing-values/values-host-network.yaml
           helm lint complex -f complex/testing-values/values-node-name.yaml
+          helm lint complex -f complex/testing-values/values-external-secret.yaml
 
   template-test:
     runs-on: ubuntu-latest
@@ -138,6 +139,7 @@ jobs:
           helm template test ./complex --debug -f complex/testing-values/values-configmap.yaml
           helm template test ./complex --debug -f complex/testing-values/values-volume-mounts.yaml
           helm template test ./complex --debug -f complex/testing-values/values-tolerations.yaml
+          helm template test ./complex --debug -f complex/testing-values/values-external-secret.yaml
 
   unit-test:
     runs-on: ubuntu-latest

--- a/complex/Chart.lock
+++ b/complex/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.1.0
 - name: lib-kubernetes
   repository: file://../lib-kubernetes
-  version: 0.5.0
+  version: 0.5.1
 - name: lib-prometheus
   repository: file://../lib-prometheus
   version: 0.1.7
-digest: sha256:a7057c5d70600cc8d8fc105f8db11f7d4c1e0db3e118a0760760e49e874c9e7d
-generated: "2025-07-18T18:32:53.762973+02:00"
+digest: sha256:4b2db0713e54983b80f8fcf11c4f3dc767d1f5bd0ab3e6f9def85494c094cff2
+generated: "2026-06-29T16:49:02.728864+02:00"

--- a/complex/Chart.yaml
+++ b/complex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: complex
 description: For deploying applications with consumers and cronjobs
 type: application
-version: 1.8.9
+version: 1.9.0
 kubeVersion: ">= 1.25.0-0 < 2.0.0-0"
 
 dependencies:

--- a/complex/Chart.yaml
+++ b/complex/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: "0.1.0"
     repository: "file://../lib-gitlab"
   - name: lib-kubernetes
-    version: "0.5.0"
+    version: "0.5.1"
     repository: "file://../lib-kubernetes"
   - name: lib-prometheus
     version: "0.1.7"

--- a/complex/Chart.yaml
+++ b/complex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: complex
 description: For deploying applications with consumers and cronjobs
 type: application
-version: 1.8.7
+version: 1.8.8
 kubeVersion: ">= 1.25.0-0 < 2.0.0-0"
 
 dependencies:
@@ -10,7 +10,7 @@ dependencies:
     version: "0.1.0"
     repository: "file://../lib-gitlab"
   - name: lib-kubernetes
-    version: "0.5.0"
+    version: "0.5.1"
     repository: "file://../lib-kubernetes"
   - name: lib-prometheus
     version: "0.1.7"

--- a/complex/README.md
+++ b/complex/README.md
@@ -1,6 +1,8 @@
+
+
 # complex
 
-![Version: 1.8.5](https://img.shields.io/badge/Version-1.8.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.8.8](https://img.shields.io/badge/Version-1.8.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 For deploying applications, consumers and cronjobs
 
@@ -10,6 +12,7 @@ The **complex** Helm chart provides a comprehensive solution for deploying conta
 
 - **ConfigMap integration**: Environment variables and file mounting from ConfigMaps
 - **Secret integration**: Environment variables and file mounting from Secrets 
+- **ExternalSecret integration**: Generate External Secrets Operator resources
 - **Volume mounts**: Mount ConfigMaps and Secrets as files with custom paths
 - **Persistent storage**: Create new PVCs or reference existing ones for shared storage (EFS)
 - **Consumer workloads**: Support for consumer-type deployments
@@ -292,6 +295,62 @@ components:
 3. **Global envFrom** (`global.container.envs.from.*`)
 4. **Global hardcoded values** (`global.container.envs.values`)
 
+### External Secrets
+
+ExternalSecret resources can be declared under `externalSecrets`. Each entry renders one `ExternalSecret` with a raw `spec`, so provider-specific fields and newer CRD fields can be passed through without chart changes. Helm templating is not applied inside `spec`, which keeps External Secrets Operator template expressions such as `{{ .password }}` intact.
+
+```yaml
+global:
+  container:
+    envs:
+      from:
+        secrets:
+          - name: app-admin-vault-envs
+            optional: true
+
+externalSecrets:
+  app-admin-vault-envs:
+    spec:
+      dataFrom:
+        - extract:
+            conversionStrategy: Default
+            decodingStrategy: None
+            key: dev/admin/envs
+            metadataPolicy: None
+      refreshInterval: 60s
+      secretStoreRef:
+        kind: SecretStore
+        name: vault-secret-store
+      target:
+        creationPolicy: Owner
+        deletionPolicy: Retain
+        name: app-admin-vault-envs
+        template:
+          engineVersion: v2
+          mergePolicy: Replace
+          metadata:
+            annotations:
+              managed: ExternalSecretsOperator
+```
+
+For review environments where the remote secret path may not exist, disable the ExternalSecret in that environment and keep the pod reference optional:
+
+```yaml
+externalSecrets:
+  app-admin-vault-envs:
+    enabled: false
+
+global:
+  container:
+    envs:
+      from:
+        secrets:
+          - name: app-admin-vault-envs
+            optional: true
+```
+
+If you need External Secrets Operator to merge into a pre-created Secret, set `spec.target.creationPolicy: Merge` and create/manage that target Secret outside the ExternalSecret.
+
 ### Volume Mounts Priority
 
 Volume mounts support **granular overrides** where components can override just `configMaps` or just `secrets`:
@@ -557,6 +616,7 @@ The following complete configuration examples are available in the `testing-valu
 
 - [`values-minimal.yaml`](testing-values/values-minimal.yaml) - Basic HTTP service
 - [`values-configmap.yaml`](testing-values/values-configmap.yaml) - ConfigMap integration
+- [`values-external-secret.yaml`](testing-values/values-external-secret.yaml) - ExternalSecret integration
 - [`values-volume-mounts.yaml`](testing-values/values-volume-mounts.yaml) - Volume mount examples
 - [`values-pvc.yaml`](testing-values/values-pvc.yaml) - PersistentVolumeClaim examples
 - [`values-pvc-efs-shared.yaml`](testing-values/values-pvc-efs-shared.yaml) - Shared storage with existing PVCs
@@ -572,13 +632,14 @@ Kubernetes: `>= 1.25.0-0 < 2.0.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../lib-gitlab | lib-gitlab | 0.1.0 |
-| file://../lib-kubernetes | lib-kubernetes | 0.5.0 |
+| file://../lib-kubernetes | lib-kubernetes | 0.5.1 |
 | file://../lib-prometheus | lib-prometheus | 0.1.7 |
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| externalSecrets | object | `{}` |  |
 | global.container.envs.from.configMaps | list | `[]` |  |
 | global.container.envs.from.secrets | list | `[]` |  |
 | global.container.envs.values | object | `{}` |  |

--- a/complex/README.md
+++ b/complex/README.md
@@ -2,7 +2,7 @@
 
 # complex
 
-![Version: 1.8.8](https://img.shields.io/badge/Version-1.8.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 For deploying applications, consumers and cronjobs
 

--- a/complex/README.md.gotmpl
+++ b/complex/README.md.gotmpl
@@ -14,6 +14,7 @@ The **complex** Helm chart provides a comprehensive solution for deploying conta
 
 - **ConfigMap integration**: Environment variables and file mounting from ConfigMaps
 - **Secret integration**: Environment variables and file mounting from Secrets  
+- **ExternalSecret integration**: Generate External Secrets Operator resources
 - **Volume mounts**: Mount ConfigMaps and Secrets as files with custom paths
 - **Persistent storage**: Create new PVCs or reference existing ones for shared storage (EFS)
 - **Consumer workloads**: Support for consumer-type deployments
@@ -296,6 +297,62 @@ components:
 3. **Global envFrom** (`global.container.envs.from.*`)
 4. **Global hardcoded values** (`global.container.envs.values`)
 
+### External Secrets
+
+ExternalSecret resources can be declared under `externalSecrets`. Each entry renders one `ExternalSecret` with a raw `spec`, so provider-specific fields and newer CRD fields can be passed through without chart changes. Helm templating is not applied inside `spec`, which keeps External Secrets Operator template expressions such as `{{ "{{ .password }}" }}` intact.
+
+```yaml
+global:
+  container:
+    envs:
+      from:
+        secrets:
+          - name: app-admin-vault-envs
+            optional: true
+
+externalSecrets:
+  app-admin-vault-envs:
+    spec:
+      dataFrom:
+        - extract:
+            conversionStrategy: Default
+            decodingStrategy: None
+            key: dev/admin/envs
+            metadataPolicy: None
+      refreshInterval: 60s
+      secretStoreRef:
+        kind: SecretStore
+        name: vault-secret-store
+      target:
+        creationPolicy: Owner
+        deletionPolicy: Retain
+        name: app-admin-vault-envs
+        template:
+          engineVersion: v2
+          mergePolicy: Replace
+          metadata:
+            annotations:
+              managed: ExternalSecretsOperator
+```
+
+For review environments where the remote secret path may not exist, disable the ExternalSecret in that environment and keep the pod reference optional:
+
+```yaml
+externalSecrets:
+  app-admin-vault-envs:
+    enabled: false
+
+global:
+  container:
+    envs:
+      from:
+        secrets:
+          - name: app-admin-vault-envs
+            optional: true
+```
+
+If you need External Secrets Operator to merge into a pre-created Secret, set `spec.target.creationPolicy: Merge` and create/manage that target Secret outside the ExternalSecret.
+
 ### Volume Mounts Priority
 
 Volume mounts support **granular overrides** where components can override just `configMaps` or just `secrets`:
@@ -561,6 +618,7 @@ The following complete configuration examples are available in the `testing-valu
 
 - [`values-minimal.yaml`](testing-values/values-minimal.yaml) - Basic HTTP service
 - [`values-configmap.yaml`](testing-values/values-configmap.yaml) - ConfigMap integration
+- [`values-external-secret.yaml`](testing-values/values-external-secret.yaml) - ExternalSecret integration
 - [`values-volume-mounts.yaml`](testing-values/values-volume-mounts.yaml) - Volume mount examples
 - [`values-pvc.yaml`](testing-values/values-pvc.yaml) - PersistentVolumeClaim examples
 - [`values-pvc-efs-shared.yaml`](testing-values/values-pvc-efs-shared.yaml) - Shared storage with existing PVCs

--- a/complex/templates/externalSecret.yaml
+++ b/complex/templates/externalSecret.yaml
@@ -6,8 +6,8 @@
 apiVersion: {{ tpl (($externalSecret.apiVersion | default "external-secrets.io/v1") | toString) $ }}
 kind: ExternalSecret
 metadata:
-  name: {{ tpl (($externalSecret.name | default $externalSecretName) | toString) $ }}
-  namespace: {{ tpl (($externalSecret.namespace | default $.Release.Namespace) | toString) $ }}
+  name: {{ tpl (($externalSecret.name | default $externalSecretName) | toString) $ | quote }}
+  namespace: {{ tpl (($externalSecret.namespace | default $.Release.Namespace) | toString) $ | quote }}
   labels:
     app.kubernetes.io/name: {{ $.Chart.Name }}
     app.kubernetes.io/instance: {{ $.Release.Name }}

--- a/complex/templates/externalSecret.yaml
+++ b/complex/templates/externalSecret.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.externalSecrets }}
+{{- range $externalSecretName, $externalSecret := .Values.externalSecrets }}
+{{- if or (not (hasKey $externalSecret "enabled")) $externalSecret.enabled }}
+{{- $externalSecretSpec := required (printf "externalSecrets.%s.spec is required when enabled" $externalSecretName) $externalSecret.spec }}
+---
+apiVersion: {{ tpl (($externalSecret.apiVersion | default "external-secrets.io/v1") | toString) $ }}
+kind: ExternalSecret
+metadata:
+  name: {{ tpl (($externalSecret.name | default $externalSecretName) | toString) $ }}
+  namespace: {{ tpl (($externalSecret.namespace | default $.Release.Namespace) | toString) $ }}
+  labels:
+    app.kubernetes.io/name: {{ $.Chart.Name }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/component: external-secret
+    {{- with $externalSecret.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $externalSecret.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{ toYaml $externalSecretSpec | indent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/complex/testing-values/values-external-secret.yaml
+++ b/complex/testing-values/values-external-secret.yaml
@@ -1,0 +1,54 @@
+global:
+  container:
+    image:
+      repository: cookielab/deployer
+      tag: 1.0.0-rc2
+    envs:
+      from:
+        secrets:
+          - name: app-admin-vault-envs
+            optional: true
+
+externalSecrets:
+  app-admin-vault-envs:
+    spec:
+      dataFrom:
+        - extract:
+            conversionStrategy: Default
+            decodingStrategy: None
+            key: dev/admin/envs
+            metadataPolicy: None
+      refreshInterval: 60s
+      secretStoreRef:
+        kind: SecretStore
+        name: vault-secret-store
+      target:
+        creationPolicy: Owner
+        deletionPolicy: Retain
+        name: app-admin-vault-envs
+        template:
+          engineVersion: v2
+          mergePolicy: Replace
+          metadata:
+            annotations:
+              managed: ExternalSecretsOperator
+
+components:
+  api:
+    type: http
+    replicas: 2
+    ports:
+      - port: 3000
+    probes:
+      readinessProbe:
+        httpGet:
+          port: 8080
+          path: /health-check
+      livenessProbe:
+        httpGet:
+          port: 8080
+          path: /health-check
+    targetGroup:
+      arn: "arn:fake"
+      securityGroupIds:
+        - sg-fake

--- a/complex/tests/deployment_core_test.yaml
+++ b/complex/tests/deployment_core_test.yaml
@@ -162,6 +162,29 @@ tests:
             configMapRef:
               name: app-config
 
+  - it: renders optional envFrom object references
+    set:
+      components.api.envs.from:
+        secrets:
+          - name: app-secret
+            optional: true
+        configMaps:
+          - name: app-config
+            optional: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: app-secret
+              optional: true
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: app-config
+              optional: true
+
   - it: inherits resources from global container settings
     asserts:
       - equal:

--- a/complex/tests/external_secret_test.yaml
+++ b/complex/tests/external_secret_test.yaml
@@ -1,0 +1,129 @@
+suite: ExternalSecret rendering
+release:
+  name: test
+  namespace: dev
+templates:
+  - templates/externalSecret.yaml
+values:
+  - ../testing-values/values-minimal.yaml
+tests:
+  - it: does not render any ExternalSecret when externalSecrets is unset
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders an ExternalSecret from raw spec
+    set:
+      externalSecrets:
+        app-admin-vault-envs:
+          spec:
+            dataFrom:
+              - extract:
+                  conversionStrategy: Default
+                  decodingStrategy: None
+                  key: dev/admin/envs
+                  metadataPolicy: None
+            refreshInterval: 60s
+            secretStoreRef:
+              kind: SecretStore
+              name: vault-secret-store
+            target:
+              creationPolicy: Owner
+              deletionPolicy: Retain
+              name: app-admin-vault-envs
+              template:
+                engineVersion: v2
+                mergePolicy: Replace
+                metadata:
+                  annotations:
+                    managed: ExternalSecretsOperator
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: apiVersion
+          value: external-secrets.io/v1
+      - equal:
+          path: metadata.name
+          value: app-admin-vault-envs
+      - equal:
+          path: metadata.namespace
+          value: dev
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: external-secret
+      - equal:
+          path: spec.secretStoreRef.name
+          value: vault-secret-store
+      - equal:
+          path: spec.dataFrom[0].extract.key
+          value: dev/admin/envs
+      - equal:
+          path: spec.target.creationPolicy
+          value: Owner
+      - equal:
+          path: spec.target.template.metadata.annotations.managed
+          value: ExternalSecretsOperator
+
+  - it: supports apiVersion and metadata overrides while preserving raw spec templates
+    set:
+      externalSecrets:
+        envs:
+          apiVersion: external-secrets.io/v1beta1
+          name: "{{ .Release.Name }}-envs"
+          namespace: custom
+          labels:
+            owner: platform
+          annotations:
+            source: helm
+          spec:
+            dataFrom:
+              - extract:
+                  key: "{{ .Release.Namespace }}/admin/envs"
+            secretStoreRef:
+              kind: ClusterSecretStore
+              name: vault
+            target:
+              creationPolicy: Merge
+              name: "{{ .Release.Name }}-envs"
+              template:
+                engineVersion: v2
+                data:
+                  connection: "postgres://{{ .username }}:{{ .password }}@postgres"
+    asserts:
+      - equal:
+          path: apiVersion
+          value: external-secrets.io/v1beta1
+      - equal:
+          path: metadata.name
+          value: test-envs
+      - equal:
+          path: metadata.namespace
+          value: custom
+      - equal:
+          path: metadata.labels.owner
+          value: platform
+      - equal:
+          path: metadata.annotations.source
+          value: helm
+      - equal:
+          path: spec.dataFrom[0].extract.key
+          value: "{{ .Release.Namespace }}/admin/envs"
+      - equal:
+          path: spec.target.creationPolicy
+          value: Merge
+      - equal:
+          path: spec.target.name
+          value: "{{ .Release.Name }}-envs"
+      - equal:
+          path: spec.target.template.data.connection
+          value: "postgres://{{ .username }}:{{ .password }}@postgres"
+
+  - it: skips disabled ExternalSecret entries
+    set:
+      externalSecrets:
+        app-admin-vault-envs:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/complex/values.schema.json
+++ b/complex/values.schema.json
@@ -1120,17 +1120,39 @@
         "secrets": {
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/envsFromRef"
           }
         },
         "configMaps": {
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/envsFromRef"
           }
         }
       },
       "additionalProperties": false
+    },
+    "envsFromRef": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "optional": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "container": {
       "type": "object",
@@ -2792,6 +2814,52 @@
         "required": [
           "data"
         ],
+        "additionalProperties": false
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "description": "ExternalSecret resources to be created",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Controls whether this ExternalSecret is rendered. Defaults to true when the entry is present."
+          },
+          "apiVersion": {
+            "type": "string",
+            "description": "ExternalSecret apiVersion to render.",
+            "default": "external-secrets.io/v1"
+          },
+          "name": {
+            "type": "string",
+            "description": "Override metadata.name. Defaults to the externalSecrets map key."
+          },
+          "namespace": {
+            "type": "string",
+            "description": "Override metadata.namespace. Defaults to the Helm release namespace."
+          },
+          "labels": {
+            "type": "object",
+            "description": "Additional labels for the ExternalSecret.",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "annotations": {
+            "type": "object",
+            "description": "Additional annotations for the ExternalSecret.",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "spec": {
+            "type": "object",
+            "description": "ExternalSecret spec rendered as-is. Helm tpl is not applied so External Secrets Operator templates are preserved.",
+            "additionalProperties": true
+          }
+        },
         "additionalProperties": false
       }
     },

--- a/complex/values.yaml
+++ b/complex/values.yaml
@@ -23,3 +23,5 @@ global:
     maxSurge: 100%
   service:
     type: ClusterIP
+
+externalSecrets: {}

--- a/lib-kubernetes/Chart.yaml
+++ b/lib-kubernetes/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: lib-kubernetes
 description: Annotations and Labels for Kubernetes
 type: library
-version: 0.5.0
+version: 0.5.1

--- a/lib-kubernetes/templates/_container.tpl
+++ b/lib-kubernetes/templates/_container.tpl
@@ -87,13 +87,27 @@ env:
 {{- $valuesConfigMaps := concat $specificConfigMaps $globalConfigMaps -}}
 {{- if or $valuesSecrets $valuesConfigMaps -}}
 envFrom:
-  {{- range $valuesSecrets }}
+  {{- range $secret := $valuesSecrets }}
   - secretRef:
-      name: {{ . }}
+      {{- if kindIs "string" $secret }}
+      name: {{ $secret }}
+      {{- else if kindIs "map" $secret }}
+      name: {{ required "envs.from.secrets[].name is required when item is an object" $secret.name }}
+      {{- if hasKey $secret "optional" }}
+      optional: {{ $secret.optional }}
+      {{- end }}
+      {{- end }}
   {{- end -}}
-  {{- range $valuesConfigMaps }}
+  {{- range $configMap := $valuesConfigMaps }}
   - configMapRef:
-      name: {{ . }}
+      {{- if kindIs "string" $configMap }}
+      name: {{ $configMap }}
+      {{- else if kindIs "map" $configMap }}
+      name: {{ required "envs.from.configMaps[].name is required when item is an object" $configMap.name }}
+      {{- if hasKey $configMap "optional" }}
+      optional: {{ $configMap.optional }}
+      {{- end }}
+      {{- end }}
   {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Render ExternalSecret resources from raw spec values, preserve ESO template expressions, support optional envFrom object refs, and include external-secret values in CI coverage.